### PR TITLE
Adding a configuration preprocessor

### DIFF
--- a/hopper/src/main/java/org/atomhopper/AtomHopperServlet.java
+++ b/hopper/src/main/java/org/atomhopper/AtomHopperServlet.java
@@ -26,6 +26,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
+import org.atomhopper.config.AtomHopperConfigurationPreprocessor;
 import org.atomhopper.servlet.DefaultEmptyContext;
 import org.atomhopper.util.config.resource.file.FileConfigurationResource;
 import org.slf4j.Logger;
@@ -114,6 +115,10 @@ public final class AtomHopperServlet extends AbderaServlet {
     @Override
     protected Provider createProvider() {
         final WorkspaceProvider workspaceProvider = new WorkspaceProvider(getHostConfiguration());
+        
+        final AtomHopperConfigurationPreprocessor preprocessor = new AtomHopperConfigurationPreprocessor(configuration);
+        configuration = preprocessor.applyDefaults().getConfig();
+        
         ConfigurationDefaults configurationDefaults = configuration.getDefaults();
         workspaceProvider.init(abderaReference, parseDefaults(configurationDefaults));
 
@@ -127,7 +132,7 @@ public final class AtomHopperServlet extends AbderaServlet {
 
         workspaceProvider.addFilter(new JSONFilter());
 
-        WorkspaceProviderConfigurationPreprocessor.setDefaults(workspaceProvider, configurationDefaults);
+//        WorkspaceProviderConfigurationPreprocessor.setDefaults(workspaceProvider, configurationDefaults);
 
         return workspaceProvider;
     }

--- a/hopper/src/main/java/org/atomhopper/config/AtomHopperConfigurationPreprocessor.java
+++ b/hopper/src/main/java/org/atomhopper/config/AtomHopperConfigurationPreprocessor.java
@@ -1,0 +1,49 @@
+package org.atomhopper.config;
+
+import java.util.List;
+import org.apache.commons.lang.StringUtils;
+import org.atomhopper.config.v1_0.*;
+
+/**
+ *
+ * @author zinic
+ */
+public class AtomHopperConfigurationPreprocessor {
+
+   private final Configuration config;
+
+   public AtomHopperConfigurationPreprocessor(Configuration config) {
+      this.config = config;
+   }
+
+   public AtomHopperConfigurationPreprocessor applyDefaults() {
+      final ConfigurationDefaults defaults = config.getDefaults();
+      setDefaultAuthor(config.getWorkspace(), defaults.getAuthor());
+
+      return new AtomHopperConfigurationPreprocessor(config);
+   }
+
+   public Configuration getConfig() {
+      return config;
+   }
+
+   private void setDefaultAuthor(List<WorkspaceConfiguration> workspaces, Author globalAuthorDefault) {
+      for (WorkspaceConfiguration workspace : workspaces) {
+         final Author workspaceAuthorDefault = workspace.getDefaults().getAuthor();
+         final Author authorToApply = isAuthorEmpty(workspaceAuthorDefault)
+                 ? globalAuthorDefault : workspaceAuthorDefault;
+
+         if (!isAuthorEmpty(authorToApply)) {
+            for (FeedConfiguration feed : workspace.getFeed()) {
+               if (isAuthorEmpty(feed.getAuthor())) {
+                  feed.setAuthor(globalAuthorDefault);
+               }
+            }
+         }
+      }
+   }
+
+   private boolean isAuthorEmpty(Author author) {
+      return author == null && StringUtils.isBlank(author.getName());
+   }
+}


### PR DESCRIPTION
The patch below creates a preprocessor that will read in the configuration and apply defaults to the entire configuration object tree. This occurs before the workspace handlers are built
thus ensuring that the handlers see the correct values.
