### PR TITLE
Fix for /srv/tomcat/webapps permission clobber 

### DIFF
--- a/ah-war/pom.xml
+++ b/ah-war/pom.xml
@@ -100,7 +100,8 @@
                         </executions>
                         <configuration>
                             <copyright>Apache License, Version 2.0</copyright>
-                            <group>Rackspace - Cloud Integration Team</group>
+                            <group>Applications/Communications</group>
+                            <packager>Rackspace - Cloud Integration Team</packager>
                             <description>ATOM Hopper - The ATOMPub Java Server</description>
                             <mappings>
                                 <mapping>
@@ -160,6 +161,7 @@
                                     <groupname>tomcat</groupname>
                                     <!-- Modify file permissions as needed -->
                                     <filemode>644</filemode>                            
+                                    <directoryIncluded>false</directoryIncluded>
                                     <sources>
                                         <source>
                                             <location>target/ah-war-${project.version}.war</location>


### PR DESCRIPTION
Excluding the directory /srv/tomcat/webapps when creating the file. 
