### PR TITLE
Change permission on /var/log/atomhopper

### DIFF
--- a/atomhopper/pom.xml
+++ b/atomhopper/pom.xml
@@ -201,7 +201,7 @@
                                     <username>tomcat</username>
                                     <groupname>tomcat</groupname>
                                     <!-- Modify file permissions as needed -->
-                                    <filemode>644</filemode>
+                                    <filemode>755</filemode>
                                     <configuration>false</configuration>
                                     <directoryIncluded>true</directoryIncluded>
                                     <sources>


### PR DESCRIPTION
Was 644 needs to be 755 to allow tomcat7 to write to directory.

... write log files.
