### PR TITLE
Fix an issue when a shorter than usual marker is used, an HTTP 500 was t...

### DIFF
--- a/hopper/src/main/java/org/atomhopper/abdera/filter/FeedEntityTagProcessor.java
+++ b/hopper/src/main/java/org/atomhopper/abdera/filter/FeedEntityTagProcessor.java
@@ -15,6 +15,10 @@ public class FeedEntityTagProcessor implements AdapterResponseInterceptor<Feed> 
     public void process(RequestContext rc, AdapterResponse<Feed> adapterResponse) {
         final Feed f = adapterResponse.getBody();
 
+        if(f == null) {
+            return;
+        }
+
         final int totalEntries = f.getEntries().size();
 
         // If there are no entries in the feed


### PR DESCRIPTION
...hrown but should've been a 404
