### PR TITLE
Upgrade tomcat-jdbc version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
             <dependency>
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>tomcat-jdbc</artifactId>
-                <version>7.0.19</version>
+                <version>7.0.27</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Current tomcat jdbc version has cyclic dependency on the same module,
which causes build failures in some dependency management tool like ivy
- ant.
  Please see the dependency in tomcat jdbc 7.0.19 : http://repo1.maven.org/maven2/org/apache/tomcat/tomcat-jdbc/7.0.19/tomcat-jdbc-7.0.19.pom, the dependency includes self reference as 

``` xml
<dependency>
<groupId>org.apache.tomcat</groupId>
<artifactId>tomcat-jdbc</artifactId>
<version>7.0.19</version>
<scope>compile</scope>
</dependency>

```

I have tested with 7.0.27 and updated it. If required We can update to latest version also,
