### PR TITLE
B-51009: add Around Advice that knows how to retry connection failures from Postgres/Tomcat JDBC connection pool

### DIFF
--- a/adapters/jdbc/pom.xml
+++ b/adapters/jdbc/pom.xml
@@ -47,6 +47,21 @@
         </dependency>
 
         <dependency>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjrt</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjweaver</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>cglib</groupId>
+            <artifactId>cglib-nodep</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/adapters/jdbc/src/main/java/org/atomhopper/jdbc/adapter/JdbcRetryOnFailureAdvice.java
+++ b/adapters/jdbc/src/main/java/org/atomhopper/jdbc/adapter/JdbcRetryOnFailureAdvice.java
@@ -1,0 +1,87 @@
+package org.atomhopper.jdbc.adapter;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.postgresql.util.PSQLException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataAccessResourceFailureException;
+
+/**
+ * This class is an Around Advice meant to surround a call to the JdbcTemplate accessing
+ * a Postgres database.
+ *
+ * User: shin4590
+ * Date: 7/23/13
+ * Time: 4:21 PM
+ */
+public class JdbcRetryOnFailureAdvice {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JdbcRetryOnFailureAdvice.class);
+
+    private String sqlStatesToRetry = "";
+
+    private int maxRetriesOnConnDrop = 0;
+
+    private long retryWaitInMillis = 1000;
+
+    public Object retryOnFailure(ProceedingJoinPoint jp) throws Throwable {
+        Object result = null;
+        int retryCount = 0;
+        do {
+            try {
+                Object[] args = jp.getArgs();
+                if ( args != null && args.length > 0 )
+                    result = jp.proceed(jp.getArgs());
+                else
+                    result = jp.proceed();
+                break;
+            } catch (DataAccessResourceFailureException ex) {
+                if ( ex.getCause() instanceof PSQLException ) {
+                    PSQLException psqlEx = (PSQLException) ex.getCause();
+                    String sqlState = psqlEx.getSQLState();
+                    LOG.warn("Got exception with sqlState=" + sqlState + ": " + ex);
+                    if ( sqlStatesToRetry.contains(sqlState) && retryCount < maxRetriesOnConnDrop ) {
+                        LOG.warn("Retrying...(retryCount=" + retryCount + ")");
+                        sleep(retryWaitInMillis);
+                    } else {
+                        throw ex;
+                    }
+                }
+            }
+            retryCount++;
+        } while ( retryCount <= maxRetriesOnConnDrop );
+        return result;
+    }
+
+    public String getSqlStatesToRetry() {
+        return sqlStatesToRetry;
+    }
+
+    public void setSqlStatesToRetry(String sqlStatesToRetry) {
+        this.sqlStatesToRetry = sqlStatesToRetry;
+    }
+
+    public int getMaxRetriesOnConnDrop() {
+        return maxRetriesOnConnDrop;
+    }
+
+    public void setMaxRetriesOnConnDrop(int maxRetriesOnConnDrop) {
+        this.maxRetriesOnConnDrop = maxRetriesOnConnDrop;
+    }
+
+    public long getRetryWaitInMillis() {
+        return retryWaitInMillis;
+    }
+
+    public void setRetryWaitInMillis(long retryWaitInMillis) {
+        this.retryWaitInMillis = retryWaitInMillis;
+    }
+
+    private void sleep(long sleepTime) {
+        try {
+            Thread.sleep(sleepTime);
+        } catch(Exception ex) {
+            // ignore
+        }
+    }
+}

--- a/adapters/jdbc/src/test/java/org/atomhopper/jdbc/adapter/JdbcRetryOnFailureAdviceTest.java
+++ b/adapters/jdbc/src/test/java/org/atomhopper/jdbc/adapter/JdbcRetryOnFailureAdviceTest.java
@@ -1,0 +1,64 @@
+package org.atomhopper.jdbc.adapter;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+import org.springframework.dao.DataAccessResourceFailureException;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * User: shin4590
+ * Date: 7/23/13
+ * Time: 8:48 PM
+ */
+@RunWith(Enclosed.class)
+public class JdbcRetryOnFailureAdviceTest {
+
+    public static class WhenPostingEntries {
+
+        private JdbcRetryOnFailureAdvice jdbcRetryOnFailureAdvice;
+        private ProceedingJoinPoint jointPoint;
+
+        @Before
+        public void setUp() throws Exception {
+
+            jointPoint = mock(ProceedingJoinPoint.class);
+
+            jdbcRetryOnFailureAdvice = new JdbcRetryOnFailureAdvice();
+        }
+
+        @Test
+        public void shouldRetryWhenFailure() throws Throwable {
+            jdbcRetryOnFailureAdvice.setMaxRetriesOnConnDrop(2);
+            jdbcRetryOnFailureAdvice.setRetryWaitInMillis(10);
+            jdbcRetryOnFailureAdvice.setSqlStatesToRetry(PSQLState.CONNECTION_UNABLE_TO_CONNECT.getState());
+
+            when(jointPoint.getArgs()).thenReturn(null);
+            when(jointPoint.proceed())
+                                .thenThrow(new DataAccessResourceFailureException("foo", new PSQLException("foo", PSQLState.CONNECTION_UNABLE_TO_CONNECT)))
+                                .thenReturn(null);
+            jdbcRetryOnFailureAdvice.retryOnFailure(jointPoint);
+            verify(jointPoint, times(2)).proceed();
+        }
+
+        @Test(expected=DataAccessResourceFailureException.class)
+        public void shouldRetryUpToMaxRetries() throws Throwable {
+            jdbcRetryOnFailureAdvice.setMaxRetriesOnConnDrop(2);
+            jdbcRetryOnFailureAdvice.setRetryWaitInMillis(10);
+            jdbcRetryOnFailureAdvice.setSqlStatesToRetry(PSQLState.CONNECTION_UNABLE_TO_CONNECT.getState());
+
+            when(jointPoint.getArgs()).thenReturn(null);
+            when(jointPoint.proceed())
+                                .thenThrow(new DataAccessResourceFailureException("foo", new PSQLException("foo", PSQLState.CONNECTION_UNABLE_TO_CONNECT)))
+                                .thenThrow(new DataAccessResourceFailureException("foo", new PSQLException("foo", PSQLState.CONNECTION_UNABLE_TO_CONNECT)))
+                                .thenThrow(new DataAccessResourceFailureException("foo", new PSQLException("foo", PSQLState.CONNECTION_UNABLE_TO_CONNECT)));
+            jdbcRetryOnFailureAdvice.retryOnFailure(jointPoint);
+            verify(jointPoint, times(3)).proceed();
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,9 @@
         <project.license>apache20</project.license>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <org.springframework.version>3.1.1.RELEASE</org.springframework.version>
+        <org.springframework.data.version>1.0.0.RELEASE</org.springframework.data.version>
+        <org.aspectj.version>1.6.9</org.aspectj.version>
+        <cglib.version>2.2</cglib.version>
     </properties>
 
     <licenses>
@@ -175,6 +178,24 @@
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-core</artifactId>
                 <version>${org.springframework.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.aspectj</groupId>
+                <artifactId>aspectjrt</artifactId>
+                <version>${org.aspectj.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.aspectj</groupId>
+                <artifactId>aspectjweaver</artifactId>
+                <version>${org.aspectj.version}</version>
+            </dependency>
+     
+            <dependency>
+                <groupId>cglib</groupId>
+                <artifactId>cglib-nodep</artifactId>
+                <version>${cglib.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This PR adds an Around Advice that can be used with the Atom Hopper JDBC adapter. 

The main use case I would like to solve with this Advice is this: 
- we are using Load Balancer (LB) VIP to connect the DB server. When we upgrade our LB software, we often times have to sever the existing connections and have the app server failover to the fail-over LB VIP. When existing connections are severed, the app server (i.e.: Atom Hopper) returns 500s to clients. With this Advice, you can configure Atom Hopper to retry up to a configurable retries and a fixed wait time between each retry. Thus, the next time we upgrade our LB software, we do not have to return 500s, thus greatly improving our availability numbers.

Another common use case that other people are more likely to experience is this:
- flaky network connection between the app server and Database server

This Advice only works when you use Atom Hopper JDBC adapter (in adapter/jdbc directory). It relies on the fact that this Atom Hopper JDBC adapter uses Spring's org.springframework.jdbc.core.JdbcTemplate.

Adding this Advice, does introduce the AspectJ jar files (3 of them: aspectrt, aspectj weaver, and cglib) into the atomhopper.war. Performance tests will be done later to verify if there are huge performance impacts with the AspectJ library. Since the use of this Advice is done from configuration, we can easily back out from using it.

To use this Advice, you will need to add something like this in the application-context.xml file:

```
  <bean id="jdbcRetryOnFailureAdvice" class="org.atomhopper.jdbc.adapter.JdbcRetryOnFailureAdvice">
      <property name="maxRetriesOnConnDrop" value="5"/>
      <property name="retryWaitInMillis" value="5000"/>
      <property name="sqlStatesToRetry" value="08003 08001 57P01"/>
  </bean>

  <aop:config proxy-target-class="true">
      <aop:aspect id="jdbcRetryOnUpdate" ref="jdbcRetryOnFailureAdvice">
          <aop:pointcut id="retryUpdatePointCut"
                        expression="execution(* org.springframework.jdbc.core.JdbcTemplate.update(..))"/>
          <aop:around   pointcut-ref="retryUpdatePointCut"
                        method="retryOnFailure"/>
      </aop:aspect>
      <aop:aspect id="jdbcRetryOnQuery" ref="jdbcRetryOnFailureAdvice">
          <aop:pointcut id="retryQueryPointCut"
                        expression="execution(* org.springframework.jdbc.core.JdbcTemplate.query(..))"/>
          <aop:around   pointcut-ref="retryQueryPointCut"
                        method="retryOnFailure"/>
      </aop:aspect>
  </aop:config>
```

The `JdbcRetryOnFailureAdvice` class has the following properties:
- maxRetriesOnConnDrop - how many times to retry an operation
- retryWaitInMillis - how many milliseconds to wait before performing the next retry
- sqlStatesToRetry - this is the SQL states string thrown by the underlying database driver. For any of these states listed here (white space separated), the operation will be retried

In the above examples, the Around Advice is configured to surround the JdbcTemplate.update() and JdbcTemplate.query() method calls. 
