### PR TITLE
B-56355 - Improve the performance of "last" page

### DIFF
--- a/adapters/hibernate/src/main/java/org/atomhopper/dbal/FeedRepository.java
+++ b/adapters/hibernate/src/main/java/org/atomhopper/dbal/FeedRepository.java
@@ -33,6 +33,4 @@ public interface FeedRepository {
     Set<PersistedCategory> updateCategories(Set<PersistedCategory> categories);
 
     PersistedEntry getNextMarker(PersistedEntry persistedEntry, String feedName, CategoryCriteriaGenerator criteriaGenerator);
-
-    Integer getFeedCount(String feedName, CategoryCriteriaGenerator criteriaGenerator);
 }

--- a/adapters/hibernate/src/main/java/org/atomhopper/hibernate/HibernateFeedRepository.java
+++ b/adapters/hibernate/src/main/java/org/atomhopper/hibernate/HibernateFeedRepository.java
@@ -282,25 +282,6 @@ public class HibernateFeedRepository implements FeedRepository {
     }
 
     @Override
-    public Integer getFeedCount(final String feedName, final CategoryCriteriaGenerator criteriaGenerator) {
-
-        return performComplexActionNonTransactionable(new ComplexSessionAction<Integer>() {
-
-            @Override
-            public Integer perform(Session liveSession) {
-                Criteria criteria = liveSession.createCriteria(PersistedEntry.class);
-
-                criteria.add(Restrictions.eq(FEED_NAME, feedName))
-                        .setProjection(Projections.rowCount());
-
-                criteriaGenerator.enhanceCriteria(criteria);
-
-                return safeLongToInt((Long) criteria.uniqueResult());
-            }
-        });
-    }
-
-    @Override
     public PersistedEntry getNextMarker(final PersistedEntry persistedEntry, final String feedName, final CategoryCriteriaGenerator criteriaGenerator) {
 
         return performComplexActionNonTransactionable(new ComplexSessionAction<PersistedEntry>() {

--- a/adapters/hibernate/src/main/java/org/atomhopper/hibernate/adapter/HibernateFeedSource.java
+++ b/adapters/hibernate/src/main/java/org/atomhopper/hibernate/adapter/HibernateFeedSource.java
@@ -196,14 +196,7 @@ public class HibernateFeedSource implements FeedSource {
             // Set the last link in the feed head
             final String baseFeedUri = decode(getFeedRequest.urlFor(new EnumKeyedTemplateParameters<URITemplate>(URITemplate.FEED)));
 
-            final int totalFeedEntryCount = feedRepository.getFeedCount(feedName, new SimpleCategoryCriteriaGenerator(searchString));
-            int lastPageSize = totalFeedEntryCount % pageSize;
-
-            if (lastPageSize == 0) {
-                lastPageSize = pageSize;
-            }
-
-            final List<PersistedEntry> lastPersistedEntries = feedRepository.getLastPage(feedName, lastPageSize, new SimpleCategoryCriteriaGenerator(searchString));
+            final List<PersistedEntry> lastPersistedEntries = feedRepository.getLastPage(feedName, pageSize, new SimpleCategoryCriteriaGenerator(searchString));
 
             if (lastPersistedEntries != null && !(lastPersistedEntries.isEmpty())) {
                 hyrdatedFeed.addLink(new StringBuilder()

--- a/adapters/jdbc/src/main/java/org/atomhopper/jdbc/query/SearchType.java
+++ b/adapters/jdbc/src/main/java/org/atomhopper/jdbc/query/SearchType.java
@@ -3,7 +3,6 @@ package org.atomhopper.jdbc.query;
 public enum SearchType {
     FEED_FORWARD,
     FEED_BACKWARD,
-    FEED_COUNT,
     FEED_HEAD,
     LAST_PAGE,
     NEXT_LINK

--- a/adapters/jdbc/src/main/java/org/atomhopper/jdbc/query/SqlBuilder.java
+++ b/adapters/jdbc/src/main/java/org/atomhopper/jdbc/query/SqlBuilder.java
@@ -18,8 +18,6 @@ public class SqlBuilder {
     private static final String OPEN_PARENS = "(";
     private static final String CLOSE_PARENS = ")";
 
-    private static final String SELECT_COUNT_FROM_ENTRIES = "SELECT COUNT(*) FROM entries WHERE feed = ?";
-
     private static final String SELECT = "SELECT * FROM entries WHERE feed = ?";
     private static final String AND = "AND";
     private static final String SPACE = " ";
@@ -116,16 +114,6 @@ public class SqlBuilder {
                 builder.append(String.format(ORDER_BY_DESC, QUESTION_MARK));
                 builder.append(CLOSE_PARENS + SPACE);
                 builder.append(String.format(ORDER_BY_DESC, QUESTION_MARK));
-
-                return builder.toString();
-
-            case FEED_COUNT:
-                builder.append(String.format(SELECT_COUNT_FROM_ENTRIES));
-
-                if (StringUtils.isNotBlank(searchSql)) {
-                    builder.append(SPACE + AND);
-                    builder.append(searchSql);
-                }
 
                 return builder.toString();
 

--- a/adapters/jdbc/src/test/java/org/atomhopper/jdbc/query/SqlBuilderTest.java
+++ b/adapters/jdbc/src/test/java/org/atomhopper/jdbc/query/SqlBuilderTest.java
@@ -11,23 +11,19 @@ public class SqlBuilderTest {
     public static class WhenCallingSearchSql {
 
         private String searchString = "(cat=D)";
-        private String classicSearchString = "+A+B";
 
         private String result_forward = "(SELECT * FROM entries WHERE feed = ? AND datelastupdated = ? AND id > ? ) UNION ALL (SELECT * FROM entries WHERE feed = ? AND datelastupdated > ? ORDER BY datelastupdated ASC, id ASC LIMIT ?) ORDER BY datelastupdated ASC, id ASC LIMIT ?";
         private String result_backward = "(SELECT * FROM entries WHERE feed = ? AND datelastupdated = ? AND id <= ? ) UNION ALL (SELECT * FROM entries WHERE feed = ? AND datelastupdated < ? ORDER BY datelastupdated DESC, id DESC LIMIT ?) ORDER BY datelastupdated DESC, id DESC LIMIT ?";
-        private String result_count = "SELECT COUNT(*) FROM entries WHERE feed = ?";
         private String result_head = "SELECT * FROM entries WHERE feed = ? ORDER BY datelastupdated DESC, id DESC LIMIT ?";
         private String result_last = "SELECT * FROM entries WHERE feed = ? ORDER BY datelastupdated ASC, id ASC LIMIT ?";
         private String result_next = "(SELECT * FROM entries WHERE feed = ? AND datelastupdated = ? AND id < ? ) UNION ALL (SELECT * FROM entries WHERE feed = ? AND datelastupdated < ? ORDER BY datelastupdated DESC, id DESC LIMIT 1) ORDER BY datelastupdated DESC, id DESC LIMIT 1";
 
         private String result_forward_with_cats = "(SELECT * FROM entries WHERE feed = ? AND datelastupdated = ? AND id > ? AND categories @> ?::varchar[] ) UNION ALL (SELECT * FROM entries WHERE feed = ? AND datelastupdated > ? AND categories @> ?::varchar[] ORDER BY datelastupdated ASC, id ASC LIMIT ?) ORDER BY datelastupdated ASC, id ASC LIMIT ?";
         private String result_backward_with_cats = "(SELECT * FROM entries WHERE feed = ? AND datelastupdated = ? AND id <= ? AND categories @> ?::varchar[] ) UNION ALL (SELECT * FROM entries WHERE feed = ? AND datelastupdated < ? AND categories @> ?::varchar[] ORDER BY datelastupdated DESC, id DESC LIMIT ?) ORDER BY datelastupdated DESC, id DESC LIMIT ?";
-        private String result_count_with_cats = "SELECT COUNT(*) FROM entries WHERE feed = ? AND categories @> ?::varchar[] ";
         private String result_head_with_cats = "SELECT * FROM entries WHERE feed = ? AND categories @> ?::varchar[] ORDER BY datelastupdated DESC, id DESC LIMIT ?";
         private String result_last_with_cats = "SELECT * FROM entries WHERE feed = ? AND categories @> ?::varchar[] ORDER BY datelastupdated ASC, id ASC LIMIT ?";
         private String result_next_with_cats = "(SELECT * FROM entries WHERE feed = ? AND datelastupdated = ? AND id < ? AND categories @> ?::varchar[] ) UNION ALL (SELECT * FROM entries WHERE feed = ? AND datelastupdated < ? AND categories @> ?::varchar[] ORDER BY datelastupdated DESC, id DESC LIMIT 1) ORDER BY datelastupdated DESC, id DESC LIMIT 1";
 
-        private String result_classic = "SELECT COUNT(*) FROM entries WHERE feed = ? AND categories && ?::varchar[] ";
         @Test
         public void ShouldGetSqlForForwad() throws Exception {
             String result = new SqlBuilder()
@@ -44,15 +40,6 @@ public class SqlBuilderTest {
                     .toString();
 
             Assert.assertEquals(result_backward, result);
-        }
-
-        @Test
-        public void ShouldGetSqlForCount() throws Exception {
-            String result = new SqlBuilder()
-                    .searchType(SearchType.FEED_COUNT)
-                    .toString();
-
-            Assert.assertEquals(result_count, result);
         }
 
         @Test
@@ -103,16 +90,6 @@ public class SqlBuilderTest {
         }
 
         @Test
-        public void ShouldGetSqlForCountWithCats() throws Exception {
-            String result = new SqlBuilder()
-                    .searchString(searchString)
-                    .searchType(SearchType.FEED_COUNT)
-                    .toString();
-
-            Assert.assertEquals(result_count_with_cats, result);
-        }
-
-        @Test
         public void ShouldGetSqlForHeadWithCats() throws Exception {
             String result = new SqlBuilder()
                     .searchString(searchString)
@@ -140,18 +117,6 @@ public class SqlBuilderTest {
                     .toString();
 
             Assert.assertEquals(result_next_with_cats, result);
-        }
-
-        @Test
-        public void ShouldGetClassicSearch() throws Exception {
-            String result = new SqlBuilder()
-                    .searchString(classicSearchString)
-                    .searchType(SearchType.FEED_COUNT)
-                    .toString();
-
-            System.out.println(result);
-
-            Assert.assertEquals(result_classic, result);
         }
     }
 }

--- a/adapters/mongodb/src/main/java/org/atomhopper/mongodb/adapter/MongodbFeedSource.java
+++ b/adapters/mongodb/src/main/java/org/atomhopper/mongodb/adapter/MongodbFeedSource.java
@@ -215,12 +215,8 @@ public class MongodbFeedSource implements FeedSource {
 
             Query feedQuery = new Query(Criteria.where(FEED).is(getFeedRequest.getFeedName()));
             simpleCategoryCriteriaGenerator.enhanceCriteria(feedQuery);
-            final int totalFeedEntryCount = safeLongToInt(countDocuments(formatCollectionName(getFeedRequest.getFeedName()), feedQuery) % pageSize);
-            int lastPageSize = pageSize;
-            if (totalFeedEntryCount != 0) {
-                lastPageSize = totalFeedEntryCount;
-            }
-            Query lastLinkQuery = new Query(Criteria.where(FEED).is(getFeedRequest.getFeedName())).limit(lastPageSize);
+
+            Query lastLinkQuery = new Query(Criteria.where(FEED).is(getFeedRequest.getFeedName())).limit(pageSize);
             simpleCategoryCriteriaGenerator.enhanceCriteria(lastLinkQuery);
             lastLinkQuery.sort().on(DATE_LAST_UPDATED, Order.ASCENDING);
             final List<PersistedEntry> lastPersistedEntries = mongoTemplate.find(lastLinkQuery,
@@ -294,18 +290,6 @@ public class MongodbFeedSource implements FeedSource {
     @Override
     public FeedInformation getFeedInformation() {
         throw new UnsupportedOperationException("Not supported yet.");
-    }
-
-    private long countDocuments(final String collection, final Query query) {
-        return mongoTemplate.execute(collection,
-                new CollectionCallback< Long>() {
-
-                    @Override
-                    public Long doInCollection(DBCollection collection)
-                            throws MongoException, DataAccessException {
-                        return collection.count(query.getQueryObject());
-                    }
-                });
     }
 
     private String urlEncode(String searchString)  {

--- a/adapters/postgres-adapter/src/main/java/org/atomhopper/postgres/adapter/PostgresFeedSource.java
+++ b/adapters/postgres-adapter/src/main/java/org/atomhopper/postgres/adapter/PostgresFeedSource.java
@@ -211,14 +211,7 @@ public class PostgresFeedSource implements FeedSource {
         final String baseFeedUri = decode(getFeedRequest.urlFor(
                 new EnumKeyedTemplateParameters<URITemplate>(URITemplate.FEED)));
 
-        int totalFeedEntryCount = getFeedCount(getFeedRequest.getFeedName(), searchString);
-
-        int lastPageSize = totalFeedEntryCount % pageSize;
-        if (lastPageSize == 0) {
-            lastPageSize = pageSize;
-        }
-
-        List<PersistedEntry> lastPersistedEntries = getLastPage(getFeedRequest.getFeedName(), lastPageSize, searchString);
+        List<PersistedEntry> lastPersistedEntries = getLastPage(getFeedRequest.getFeedName(), pageSize, searchString);
 
         if (lastPersistedEntries != null && !(lastPersistedEntries.isEmpty())) {
             hyrdatedFeed.addLink(
@@ -326,23 +319,6 @@ public class PostgresFeedSource implements FeedSource {
         List<PersistedEntry> entry = jdbcTemplate
                 .query(entrySQL, new Object[]{feedName, entryId}, new EntryRowMapper());
         return entry.size() > 0 ? entry.get(0) : null;
-    }
-
-    private Integer getFeedCount(final String feedName, final String searchString) {
-        final String totalFeedEntryCountSQL = "SELECT COUNT(*) FROM entries WHERE feed = ?";
-        final String totalFeedEntryCountWithCatsSQL = "SELECT COUNT(*) FROM entries WHERE feed = ? AND categories && ?::varchar[]";
-
-        int totalFeedEntryCount;
-
-        if (searchString.length() > 0) {
-            totalFeedEntryCount = jdbcTemplate
-                    .queryForInt(totalFeedEntryCountWithCatsSQL, feedName,
-                                 CategoryStringGenerator.getPostgresCategoryString(searchString));
-        } else {
-            totalFeedEntryCount = jdbcTemplate
-                    .queryForInt(totalFeedEntryCountSQL, feedName);
-        }
-        return totalFeedEntryCount;
     }
 
     private List<PersistedEntry> getFeedHead(final String feedName, final int pageSize, final String searchString) {


### PR DESCRIPTION
For all requests with marker = "last"
- Removed the SELECT COUNT(*) ... query; now uses default page size for all adapters.
- Ensured/added shouldGetFeedWithLastMarker() test for all adapters.
