### PR TITLE
D 15415 forward

### DIFF
--- a/adapters/jdbc/src/main/java/org/atomhopper/jdbc/adapter/JdbcFeedSource.java
+++ b/adapters/jdbc/src/main/java/org/atomhopper/jdbc/adapter/JdbcFeedSource.java
@@ -414,7 +414,8 @@ public class JdbcFeedSource implements FeedSource {
     private List<PersistedEntry> enhancedGetLastPage(final String feedName, final int pageSize,
                                                      final String searchString) {
 
-        SqlBuilder sql = new SqlBuilder().searchType(SearchType.LAST_PAGE).searchString(searchString);
+        SqlBuilder sql = new SqlBuilder().searchType( SearchType.LAST_PAGE ).searchString( searchString )
+              .feedHeadDelayInSeconds( feedHeadDelayInSeconds );
 
         List<String> categoriesList = SearchToSqlConverter.getParamsFromSearchString(searchString);
         int numCats = categoriesList.size();

--- a/adapters/jdbc/src/main/java/org/atomhopper/jdbc/query/SqlBuilder.java
+++ b/adapters/jdbc/src/main/java/org/atomhopper/jdbc/query/SqlBuilder.java
@@ -65,6 +65,20 @@ public class SqlBuilder {
                     builder.append(searchSql);
                 }
 
+                // D-15000: when we are getting feed head and there are
+                // aggressive inserts going on at the same time, Postgres
+                // does not guarantee that entries that are inserted later
+                // will have later timestamps. This is just due to the nature
+                // of multi-process and multi-threaded-ness of the database.
+                // Therefore, we return only entries that have been inserted
+                // in the database n seconds from the current select time.
+                if ( feedHeadDelayInSeconds != -1 ) {
+                    builder.append(AND);
+                    builder.append(" datelastupdated < now() - interval '");
+                    builder.append(feedHeadDelayInSeconds);
+                    builder.append(" seconds' ");
+                }
+
                 builder.append(CLOSE_PARENS);
                 builder.append(SPACE + UNION_ALL + SPACE);
                 builder.append(OPEN_PARENS);
@@ -199,6 +213,20 @@ public class SqlBuilder {
                 if (StringUtils.isNotBlank(searchSql)) {
                     builder.append(AND);
                     builder.append(searchSql);
+                }
+
+                // D-15000: when we are getting feed head and there are
+                // aggressive inserts going on at the same time, Postgres
+                // does not guarantee that entries that are inserted later
+                // will have later timestamps. This is just due to the nature
+                // of multi-process and multi-threaded-ness of the database.
+                // Therefore, we return only entries that have been inserted
+                // in the database n seconds from the current select time.
+                if ( feedHeadDelayInSeconds != -1 ) {
+                    builder.append(AND);
+                    builder.append(" datelastupdated < now() - interval '");
+                    builder.append(feedHeadDelayInSeconds);
+                    builder.append(" seconds' ");
                 }
 
                 builder.append(String.format(ORDER_BY_ASC));


### PR DESCRIPTION
FYI - the FeedForward.sh test starts with a marker=last query and then executes marker=forward queries after that.

Due to the fact that marker=last is not yet implemented with the delay, pre-existing events need to be on the feed to prevent a race condition when getting the last page.

I'd be happy to update this branch with marker=last if we think its most expedient.
