### PR TITLE
B-61218: add logging for when we're returning less entries than the limit parameter

### DIFF
--- a/adapters/jdbc/src/test/java/org/atomhopper/jdbc/adapter/JdbcFeedSourceTest.java
+++ b/adapters/jdbc/src/test/java/org/atomhopper/jdbc/adapter/JdbcFeedSourceTest.java
@@ -21,12 +21,12 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
 import org.springframework.http.HttpStatus;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import static junit.framework.Assert.assertTrue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
 import java.util.*;
@@ -407,6 +407,44 @@ public class JdbcFeedSourceTest {
             assertEquals("Should get a 200 response", HttpStatus.OK,
                     jdbcFeedSource.getEntry(getEntryRequest).getResponseStatus());
 
+        }
+
+        @Test
+        public void shouldLogUuidsWhenEnableLoggingOnShortPageIsTrue() throws Exception {
+            jdbcFeedSource.setEnableLoggingOnShortPage(Boolean.TRUE);
+            JdbcFeedSource.LOG = mock(Logger.class);
+            Abdera localAbdera = new Abdera();
+            when(jdbcTemplate.queryForObject(any(String.class),
+                    any(EntryRowMapper.class),
+                    any(String.class),
+                    any(String.class))).thenReturn(persistedEntry);
+            when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
+            when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
+            when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
+            when(jdbcTemplate.queryForInt(any(String.class), any(Object[].class))).thenReturn(1);
+            when(getFeedRequest.getPageSize()).thenReturn("13");
+            assertEquals("Should get a 200 response", HttpStatus.OK,
+                    jdbcFeedSource.getFeed(getFeedRequest).getResponseStatus());
+            verify(JdbcFeedSource.LOG, atLeastOnce()).warn(any(String.class));
+        }
+
+        @Test
+        public void shouldNotLogUuidsWhenEnableLoggingOnShortPageIsFalse() throws Exception {
+            jdbcFeedSource.setEnableLoggingOnShortPage(Boolean.FALSE);
+            JdbcFeedSource.LOG = mock(Logger.class);
+            Abdera localAbdera = new Abdera();
+            when(jdbcTemplate.queryForObject(any(String.class),
+                    any(EntryRowMapper.class),
+                    any(String.class),
+                    any(String.class))).thenReturn(persistedEntry);
+            when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
+            when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
+            when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
+            when(jdbcTemplate.queryForInt(any(String.class), any(Object[].class))).thenReturn(1);
+            when(getFeedRequest.getPageSize()).thenReturn("13");
+            assertEquals("Should get a 200 response", HttpStatus.OK,
+                    jdbcFeedSource.getFeed(getFeedRequest).getResponseStatus());
+            verify(JdbcFeedSource.LOG, never()).warn(any(String.class));
         }
     }
 }


### PR DESCRIPTION
This change is to add logging when and only when we return less entries than the limit parameter. To do this, I introduced a configurable parameter: enableLoggingOnShortPage for the JdbcFeedSource. If set to true and Logging is set to at least WARN level, then we log that we are returning less entries than the specified limit parameter. I also log the UUID. The log output looks like this:

```
2013-12-05 13:23:55 214536 [http-bio-8080-exec-1] WARN  org.atomhopper.jdbc.adapter.JdbcFeedSource - User requested usagetest7/events feed with limit 200, but returning only 62
2013-12-05 13:23:55 214551 [http-bio-8080-exec-1] WARN  org.atomhopper.jdbc.adapter.JdbcFeedSource - UUIDs: 23c558467941, urn:uuid:ad2c59c4-d401-4fa0-8088-d74577d14492, 19509c93c550, urn:uuid:880649b8-854e-4764-b2a9-9ea914823511, 967a1902703f, urn:uuid:902c00af-f1f8-4668-ba43-0e069dd35705, 8b889cd7bc5f,...
```

I only did this for the jdbc adapter because this logging is Rax specific. I can't think of any reasons why other people would want this.

To turn on this logging, you configure application-context.xml, like this:

```
  <bean name="my-jdbc-new-feed-source" class="org.atomhopper.jdbc.adapter.JdbcFeedSource">
      <property name="jdbcTemplate" ref="my-jdbc-new-read" />
      <property name="enableTimers">
          <value>false</value>
      </property>
      <property name="enableLoggingOnShortPage">
         <value>true</value>
      </property>
      <property name="feedHeadDelayInSeconds">
          <value>60</value>
      </property>
  </bean>
```
