### PR TITLE
B-37937: fix issue of wrongly calculating the entry found with the specified timestamp

### DIFF
--- a/adapters/jdbc/src/main/java/org/atomhopper/jdbc/adapter/JdbcFeedSource.java
+++ b/adapters/jdbc/src/main/java/org/atomhopper/jdbc/adapter/JdbcFeedSource.java
@@ -368,7 +368,7 @@ public class JdbcFeedSource implements FeedSource {
 
         final Feed feed = hydrateFeed(getFeedRequest.getAbdera(),
                 enhancedGetFeedPage(getFeedRequest.getFeedName(),
-                        startAt.toDate(),
+                        entryMarker.getDateLastUpdated(),
                         entryMarker.getId(),
                         pageDirection,
                         searchString, pageSize),

--- a/adapters/jdbc/src/main/java/org/atomhopper/jdbc/query/SqlBuilder.java
+++ b/adapters/jdbc/src/main/java/org/atomhopper/jdbc/query/SqlBuilder.java
@@ -31,7 +31,9 @@ public class SqlBuilder {
 
     private static final String ORDER_BY_ASC = "ORDER BY datelastupdated ASC, id ASC LIMIT ?";
     private static final String ORDER_BY_ASC_LIMIT = "ORDER BY datelastupdated ASC, id ASC LIMIT %s";
+    private static final String ORDER_BY_DATE_ASC_ID_DESC_LIMIT = "ORDER BY datelastupdated ASC, id DESC LIMIT %s";
     private static final String ORDER_BY_DESC_LIMIT = "ORDER BY datelastupdated DESC, id DESC LIMIT %s";
+    private static final String ORDER_BY_DATE_DESC_ID_ASC_LIMIT = "ORDER BY datelastupdated DESC, id ASC LIMIT %s";
     private static final String DB_TIMESTAMP_PATTERN = "yyyy-MM-dd HH:mm:ss.SSS z";
 
     public SqlBuilder searchString(String searchString) {
@@ -237,9 +239,9 @@ public class SqlBuilder {
                 builder.append(timeZone.getShortName(startingTimestamp.getMillis()));
 
                 if ( type == SearchType.BY_TIMESTAMP_BACKWARD ) {
-                    builder.append("' < '");
+                    builder.append("' <= '");
                 } else {
-                    builder.append("' > '");
+                    builder.append("' >= '");
                 }
 
                 DateTimeFormatter postgresDTF = DateTimeFormat.forPattern(DB_TIMESTAMP_PATTERN);
@@ -247,9 +249,9 @@ public class SqlBuilder {
                 builder.append("'::timestamp ");
 
                 if ( type == SearchType.BY_TIMESTAMP_BACKWARD ) {
-                    builder.append(String.format(ORDER_BY_DESC_LIMIT, 1));
+                    builder.append(String.format(ORDER_BY_DATE_DESC_ID_ASC_LIMIT, 1));
                 } else {
-                    builder.append(String.format(ORDER_BY_ASC_LIMIT, 1));
+                    builder.append(String.format(ORDER_BY_DATE_ASC_ID_DESC_LIMIT, 1));
                 }
                 return builder.toString();
 


### PR DESCRIPTION
When we're doing query to find the entries with the specified timestamp, I was initially doing: 
`order by datelastupdated desc, id desc` for direction=backward and `order by datelastupdated asc, id asc` for direction=forward.

That was the wrong query. The corrected one would be: `order by datelastupdated desc, id asc` for direction=backward and `order by datelastupdated asc, id desc` for direction=forward.

If we are paging backward, we want to get the smallest id (the oldest) of the entries with the timestamp specified so that the previous page that is built will contain only entries with older timestamp and smaller IDs.

If we are paging forward, we want to get the biggest id (the most recent) of the entries with the timestamp specified so that the next page that is built will contain only entries with newer timestamp and bigger IDs.
