### PR TITLE
B-65460: add a maven profile to upload veracode static scan

### DIFF
--- a/atomhopper/pom.xml
+++ b/atomhopper/pom.xml
@@ -94,12 +94,6 @@
             <groupId>com.yammer.metrics</groupId>
             <artifactId>metrics-servlet</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>com.rackspace.api.clients</groupId>
-            <artifactId>veracode-client</artifactId>
-            <version>1.3</version>
-        </dependency>
     </dependencies>
 
     <build>
@@ -394,21 +388,26 @@
         <profile>
             <id>upload-veracode-static-scan</id>
             <dependencies>
-               <dependency>
-                   <groupId>org.codehaus.groovy.modules.http-builder</groupId>
-                   <artifactId>http-builder</artifactId>
-                   <version>0.7</version>
-               </dependency>
-               <dependency>
-                   <groupId>org.apache.httpcomponents</groupId>
-                   <artifactId>httpclient</artifactId>
-                   <version>4.3.3</version>
-               </dependency>
-               <dependency>
-                   <groupId>org.apache.httpcomponents</groupId>
-                   <artifactId>httpcore</artifactId>
-                   <version>4.3</version>
-               </dependency>
+                <dependency>
+                    <groupId>com.rackspace.api.clients</groupId>
+                    <artifactId>veracode-client</artifactId>
+                    <version>1.3</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.codehaus.groovy.modules.http-builder</groupId>
+                    <artifactId>http-builder</artifactId>
+                    <version>0.7</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                    <version>4.3.3</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpcore</artifactId>
+                    <version>4.3</version>
+                </dependency>
             </dependencies>
             <build>
                 <plugins>


### PR DESCRIPTION
To run the uploading of the atomhopper*.war file for Veracode static scan, one can do the following:

```
mvn clean verify -P upload-veracode-static-scan --pl atomhopper -am \
    -Dbuild.number=<num> -Dveracode.username=<username> -Dveracode.password=<password>
```
