### PR TITLE
D-18135: use timeZone.getID() so Australian EST timezone can be calculated correctly

### DIFF
--- a/adapters/jdbc/src/main/java/org/atomhopper/jdbc/query/SqlBuilder.java
+++ b/adapters/jdbc/src/main/java/org/atomhopper/jdbc/query/SqlBuilder.java
@@ -236,7 +236,7 @@ public class SqlBuilder {
 
                 builder.append(AND);
                 builder.append(" (datelastupdated at time zone current_setting('TIMEZONE')) at time zone '");
-                builder.append(timeZone.getShortName(startingTimestamp.getMillis()));
+                builder.append(timeZone.getID());
 
                 if ( type == SearchType.BY_TIMESTAMP_BACKWARD ) {
                     builder.append("' <= '");


### PR DESCRIPTION
On CentOS, Australian EST timezone shortname is EST. Joda Time will treat EST as EST US, thus making the timezone calculation incorrect. timeZone.getID() will get us the correct string, which is something like "Australia/Sydney"
