### PR TITLE
fixing the order of the create entries table command to match existing tables which were added too

### DIFF
--- a/adapters/jdbc/src/main/resources/ddl/jdbc/atomhopper-fresh-schema-ddl-postgres.sql
+++ b/adapters/jdbc/src/main/resources/ddl/jdbc/atomhopper-fresh-schema-ddl-postgres.sql
@@ -23,12 +23,12 @@ CREATE TABLE entries (
     datelastupdated timestamp without time zone NOT NULL DEFAULT current_timestamp,
     entrybody text,
     feed text,
+    categories character varying[],
 -- categories which are mapped to specific columns
 -- remove if you aren't configuring your FeedSource & FeedPublisher accordingly
     eventtype text,
     tenantid text,
 -- ---------------------
-    categories character varying[],
     PRIMARY KEY(datelastupdated, id)
 );
 CREATE INDEX entryid_idx on entries(entryid);


### PR DESCRIPTION
Any tables which were created with the previous statement will not match the order of:
- tables which were previously existing had eventtype & tenantid added on them
- tables which are created from this point forward.
