### PR TITLE
D-10651 - Search '%2B' returns a 500, should return a 400

### DIFF
--- a/adapters/jdbc/src/main/java/org/atomhopper/jdbc/query/CategoryStringGenerator.java
+++ b/adapters/jdbc/src/main/java/org/atomhopper/jdbc/query/CategoryStringGenerator.java
@@ -101,6 +101,11 @@ public final class CategoryStringGenerator {
 
             switch (nextOperator) {
                 case INCLUSIVE_OPERATOR:
+                    if( searchTermBuilder.toString().isEmpty() ) {
+
+                        throw new IllegalArgumentException( "Invalid Search Parameter: Parameter cannot be empty string." );
+                    }
+
                     categories.add(searchTermBuilder.toString());
                     break;
 
@@ -116,7 +121,8 @@ public final class CategoryStringGenerator {
         int charIndex = currentCharIndex;
         boolean isEscaped = false;
 
-        do {
+
+        while( charIndex < searchString.length() ) {
             final char nextChar = searchString.charAt(charIndex);
 
             if (isEscaped || !isOperator(nextChar)) {
@@ -129,7 +135,9 @@ public final class CategoryStringGenerator {
                     return charIndex - 1;
                 }
             }
-        } while (++charIndex < searchString.length());
+
+            charIndex++;
+        }
 
         return charIndex;
     }

--- a/adapters/jdbc/src/test/java/org/atomhopper/jdbc/query/CategoryStringGeneratorTest.java
+++ b/adapters/jdbc/src/test/java/org/atomhopper/jdbc/query/CategoryStringGeneratorTest.java
@@ -26,6 +26,10 @@ public class CategoryStringGeneratorTest {
     final String COL_CAT = "+pOne:col+cat1";
     final String COL_CAT_3 = "+cat1+pOne:col+cat2";
 
+    final String EMPTY_CAT1 = "+";
+    final String EMPTY_CAT2 =  "+cat1+";
+    final String EMPTY_CAT3 = "++cat1";
+
     @Before
     public void setUp() throws Exception {
 
@@ -64,5 +68,20 @@ public class CategoryStringGeneratorTest {
         List<String> result = CategoryStringGenerator.getPostgresCategoryString(MULTI_CAT, Collections.EMPTY_MAP, null );
         assertEquals( result.size(), 1 );
         assertEquals(result.get( 0 ), MULTI_CAT_RESULT);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailEmpty1() {
+        List<String> result = CategoryStringGenerator.getPostgresCategoryString(EMPTY_CAT1, Collections.EMPTY_MAP, null );
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailEmpty2() {
+        List<String> result = CategoryStringGenerator.getPostgresCategoryString(EMPTY_CAT2, Collections.EMPTY_MAP, null );
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailEmpty3() {
+        List<String> result = CategoryStringGenerator.getPostgresCategoryString(EMPTY_CAT3, Collections.EMPTY_MAP, null );
     }
 }


### PR DESCRIPTION
- Empty search categories (any plus with no term following it, or is immediately followed by a plus) now return a 400

NOTE:  previously, any search query with a trailing '+' threw a 500, however, a search of '++term1' would return, with only 'term1' categories, not a 500.

This PR now has the following return a 400:
- '+'
- '+cat1+'
- '++cat1'

Is this a no-no because some customer might already being using #3 and getting results, and this would be a 'regression'?
