### PR TITLE
CF-1034: temporary fix for an issue with lower casing category terms

### DIFF
--- a/adapters/jdbc/src/main/java/org/atomhopper/jdbc/adapter/JdbcFeedPublisher.java
+++ b/adapters/jdbc/src/main/java/org/atomhopper/jdbc/adapter/JdbcFeedPublisher.java
@@ -258,7 +258,7 @@ public class JdbcFeedPublisher implements FeedPublisher, InitializingBean {
         }
     }
 
-    private String[] processCategories(List<org.apache.abdera.model.Category> abderaCategories) {
+    protected String[] processCategories(List<org.apache.abdera.model.Category> abderaCategories) {
         final List<String> categoriesList = new ArrayList<String>();
 
         for (org.apache.abdera.model.Category abderaCat : abderaCategories) {

--- a/adapters/jdbc/src/main/java/org/atomhopper/jdbc/adapter/JdbcFeedPublisher.java
+++ b/adapters/jdbc/src/main/java/org/atomhopper/jdbc/adapter/JdbcFeedPublisher.java
@@ -263,11 +263,14 @@ public class JdbcFeedPublisher implements FeedPublisher, InitializingBean {
 
         for (org.apache.abdera.model.Category abderaCat : abderaCategories) {
             String term = abderaCat.getTerm();
-            // CF-1034: temporary fix for not being able
-            // to search Files events using NAST ID because
-            // it is the tenantID for Cloud Files and it's
-            // being converted to all lower case here.
-            if ( term.startsWith("tid:") ) {
+            String termPrefix = "";
+            if ( StringUtils.isNotBlank(term) ) {
+                String[] parts = term.split(":");
+                if ( parts != null && parts.length>=1 ) {
+                    termPrefix = parts[0];
+                }
+            }
+            if ( mapPrefix.keySet().contains(termPrefix) ) {
                 categoriesList.add(abderaCat.getTerm());
             } else {
                 categoriesList.add(abderaCat.getTerm().toLowerCase());

--- a/adapters/jdbc/src/main/java/org/atomhopper/jdbc/adapter/JdbcFeedPublisher.java
+++ b/adapters/jdbc/src/main/java/org/atomhopper/jdbc/adapter/JdbcFeedPublisher.java
@@ -262,15 +262,8 @@ public class JdbcFeedPublisher implements FeedPublisher, InitializingBean {
         final List<String> categoriesList = new ArrayList<String>();
 
         for (org.apache.abdera.model.Category abderaCat : abderaCategories) {
-            String term = abderaCat.getTerm();
-            String termPrefix = "";
-            if ( StringUtils.isNotBlank(term) ) {
-                String[] parts = term.split(":");
-                if ( parts != null && parts.length>=1 ) {
-                    termPrefix = parts[0];
-                }
-            }
-            if ( mapPrefix.keySet().contains(termPrefix) ) {
+            String termPrefix = getPrefixFromTerm(abderaCat.getTerm());
+            if ( StringUtils.isNotEmpty(termPrefix) && mapPrefix.keySet().contains(termPrefix) ) {
                 categoriesList.add(abderaCat.getTerm());
             } else {
                 categoriesList.add(abderaCat.getTerm().toLowerCase());
@@ -281,6 +274,16 @@ public class JdbcFeedPublisher implements FeedPublisher, InitializingBean {
         categoriesList.toArray(categoryArray);
 
         return categoryArray;
+    }
+
+    private String getPrefixFromTerm(String term) {
+        if ( StringUtils.isNotBlank(term) ) {
+            String[] parts = term.split(":");
+            if ( parts != null && parts.length>=1 ) {
+                return parts[0];
+            }
+        }
+        return null;
     }
 
     private String entryToString(Entry entry) {

--- a/adapters/jdbc/src/main/java/org/atomhopper/jdbc/adapter/JdbcFeedPublisher.java
+++ b/adapters/jdbc/src/main/java/org/atomhopper/jdbc/adapter/JdbcFeedPublisher.java
@@ -262,7 +262,16 @@ public class JdbcFeedPublisher implements FeedPublisher, InitializingBean {
         final List<String> categoriesList = new ArrayList<String>();
 
         for (org.apache.abdera.model.Category abderaCat : abderaCategories) {
-            categoriesList.add(abderaCat.getTerm().toLowerCase());
+            String term = abderaCat.getTerm();
+            // CF-1034: temporary fix for not being able
+            // to search Files events using NAST ID because
+            // it is the tenantID for Cloud Files and it's
+            // being converted to all lower case here.
+            if ( term.startsWith("tid:") ) {
+                categoriesList.add(abderaCat.getTerm());
+            } else {
+                categoriesList.add(abderaCat.getTerm().toLowerCase());
+            }
         }
 
         final String[] categoryArray = new String[categoriesList.size()];


### PR DESCRIPTION
Cloud Feeds configures this JDBCAdapter with prefix map:
* tid -> tenantID
* type -> eventtype

We are making code changes that says: for any category terms with the above prefix, do not lower case the term.