### PR TITLE
CF-468: adapt latest changes to Veracode upload script

### DIFF
--- a/atomhopper/pom.xml
+++ b/atomhopper/pom.xml
@@ -426,39 +426,74 @@
                                         import com.rackspace.api.clients.veracode.DefaultVeracodeApiClient
                                         import groovy.util.AntBuilder
                                         import groovyx.net.http.HTTPBuilder
+                                        import static groovyx.net.http.ContentType.*
                                         import static groovyx.net.http.Method.*
-
-                                        def client = new DefaultVeracodeApiClient("https://analysiscenter.veracode.com/api/", '${veracode.username}', '${veracode.password}', System.out)
+    
+                                        // some globals used throughout the script
+                                        def veracodeUrl = 'https://analysiscenter.veracode.com/api/'
+                                        def platform = 'Linux'
+                                        def client = new DefaultVeracodeApiClient(veracodeUrl, '${veracode.username}',
+                                                                                  '${veracode.password}', System.out)
                                         def version = project.version
-                                        def copyFile = new File('${project.basedir}' + "/target/atomhopper.war") 
-                                        def warFile = new File('${project.basedir}', "/target/atomhopper-" + version + ".war")
-
-                                        // workaround for the veracode-client-java not taking buildVersion as String
-                                        def buildVersion = version - '-SNAPSHOT'
-                                        buildVersion = buildVersion.replaceAll("\\.","") + '${build.number}'
-                                        print "Uploading artifacts with version: " + buildVersion + "\n"
-                                        def buildVersionInt = buildVersion.toInteger()
-
-                                        // workaround for veracode wanting the same filename for each scan
-                                        new AntBuilder().copy(file:warFile.canonicalPath, tofile:copyFile.canonicalPath)
-
+    
+                                        // scanName is the version (minus -SNAPSHOT) and build number.
+                                        // an example would be: 1.11.0-1
+                                        def scanName = version - '-SNAPSHOT' + '-' + '${build.number}'
+                                        println "Submitting scan for artifacts with name: " + scanName
+    
+                                        // get the application ID
+                                        // the application must be pre-created from Veracode web UI
                                         def appId =  client.getAppId("Atom Hopper")
-                                        print "AppId = " + appId + "\n"
+                                        println "For applicationId: " + appId
+                                        println ""
 
-                                        def buildId = client.scanArtifacts([copyFile].asList(), buildVersionInt, "Atom Hopper", "Linux")
-                                        new AntBuilder().delete(file:copyFile.canonicalPath)
-       
-                                        // the pre-scan could take 3 - 5 minutes
-                                        print "Waiting for pre-scan to complete\n"
-                                        sleep 5 * 60 * 1000
-
-                                        // workaround for the java client not making HTTP call to beginscan.do
-                                        print "Submitting /api/4.0/beginscan.do\n"
-                                        def http = new HTTPBuilder("https://analysiscenter.veracode.com/api/")
+                                        def http = new HTTPBuilder(veracodeUrl)
                                         http.auth.basic '${veracode.username}', '${veracode.password}'
-                                        http.request(POST) {
-                                            uri.path = '/api/4.0/beginscan.do'
-                                            uri.query = ['app_id': appId, 'scan_all_top_level_modules': true]
+    
+                                        // Step 1 - create a new scan
+                                        println "Creating a scan build /api/4.0/createbuild.do"
+                                        def result = http.request(POST) {
+                                            uri.path = '4.0/createbuild.do'
+                                            uri.query = ['app_id': appId, 'version': scanName, 'platform': platform]
+                                            response.success = { resp ->
+                                                println 'createbuild.do completed successfully (status=${resp.status}): '
+                                                println resp.entity.content.text
+                                            }
+                                            response.failure = { resp ->
+                                                println 'createbuild.do failed (status=${resp.status}), reason:'
+                                                println resp.entity.content.text
+                                            }
+                                        }
+
+                                        // Step 2 - upload the file to scan
+                                        // Note: I could not make the MultipartEntity to work with
+                                        // HttpBuilder class. So I resorted to calling curl
+                                        println "Uploading file ${project.basedir}/target/atomhopper-${version}.war to /api/4.0/uploadfile.do"
+                                        def uploadCurl = ["curl", "--compressed",
+                                                          "-u", "${veracode.username}:${veracode.password}",
+                                                          "-F", "app_id=${appId}",
+                                                          "-F", "file=@${project.basedir}/target/atomhopper-${version}.war",
+                                                          "-F", "save_as=atomhopper.war",
+                                                          "${veracodeUrl}4.0/uploadfile.do"]
+                                        def proc = uploadCurl.execute()
+                                        Thread.start { System.err &lt;&lt; proc.err }
+                                        proc.waitFor()
+    
+                                        // Step 3 - submit the prescan with auto_scan=true
+                                        // prescan takes a few minutes, the actual scan will
+                                        // be kicked off automatically after prescan is done
+                                        println "Submitting /api/4.0/beginprescan.do"
+                                        http.request(GET) {
+                                            uri.path = '4.0/beginprescan.do'
+                                            uri.query = ['app_id': appId, 'auto_scan': true]
+                                            response.success = { resp ->
+                                                println 'prescan sent successfully (status=${resp.status}):'
+                                                println resp.entity.content.text
+                                            }
+                                            response.failure = { resp ->
+                                                println 'prescan failed (status=${resp.status}), reason:'
+                                                println resp.entity.content.text
+                                            }
                                         }
                                     </source>
                                 </configuration>


### PR DESCRIPTION
To get rid of:
* sleep 5 minutes
* limitation of buildVersion has to be integer