### PR TITLE
CF-702: fix broken tests due to JDK 1.8 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -349,6 +349,18 @@
                 <version>2.3</version>
             </dependency>
 
+            <dependency>
+                <groupId>xerces</groupId>
+                <artifactId>xercesImpl</artifactId>
+                <version>2.11.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>xml-apis</groupId>
+                <artifactId>xml-apis</artifactId>
+                <version>1.4.01</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
2 dependency libraries added:
* xercesImpl is added to solve this error:
```
org.xml.sax.SAXNotRecognizedException: Feature: http://javax.xml.XMLConstants/feature/secure-processing
```
* xml-apis is added to solve this problem:
```
java.lang.NoClassDefFoundError: org/w3c/dom/ElementTraversal
```