### PR TITLE
CF-702: added the 2 library needed at runtime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -353,13 +353,11 @@
                 <groupId>xerces</groupId>
                 <artifactId>xercesImpl</artifactId>
                 <version>2.11.0</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>xml-apis</groupId>
                 <artifactId>xml-apis</artifactId>
                 <version>1.4.01</version>
-                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
These 2 libraries, as it turns out, are needed at runtime as well. Not just tests.