### PR TITLE
Feature/concurrent category creation

### DIFF
--- a/adapters/hibernate/src/test/java/org/atomhopper/hibernate/HibernateFeedRepositoryTest.java
+++ b/adapters/hibernate/src/test/java/org/atomhopper/hibernate/HibernateFeedRepositoryTest.java
@@ -1,17 +1,35 @@
 package org.atomhopper.hibernate;
 
+import static org.mockito.Mockito.mock;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+
+import org.atomhopper.adapter.jpa.PersistedCategory;
+import org.atomhopper.adapter.jpa.PersistedEntry;
+import org.atomhopper.adapter.jpa.PersistedFeed;
 import org.atomhopper.dbal.AtomDatabaseException;
 import org.atomhopper.hibernate.actions.ComplexSessionAction;
 import org.atomhopper.hibernate.actions.SimpleSessionAction;
+import org.hibernate.Session;
+import org.hibernate.criterion.Restrictions;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.mockito.Mockito.mock;
 
 /**
  * User: sbrayman
@@ -73,15 +91,122 @@ public class HibernateFeedRepositoryTest {
         }
     }
 
-    public static class WhenGettingCategories {
+    public static class WhenCreatingEntry {
+        static HibernateFeedRepository feedRepository;
 
-        @Before
-        public void setup() throws Exception {
+        @BeforeClass
+        public static void setup() throws Exception {
+            Map<String, String> parameters;
+            parameters = new HashMap<String, String>();
+            parameters.put("hibernate.connection.driver_class", "org.h2.Driver");
+            parameters.put("hibernate.connection.url", "jdbc:h2:mem:WhenCreatingFeed");
+            parameters.put("hibernate.dialect", "org.hibernate.dialect.H2Dialect");
+            parameters.put("hibernate.connection.username", "sa");
+            parameters.put("hibernate.connection.password", "");
+            parameters.put("hibernate.hbm2ddl.auto", "update");
 
+            feedRepository = new HibernateFeedRepository(parameters);
+
+            PersistedEntry entry = new PersistedEntry("entryId");
+            entry.setCategories(Collections.singleton(new PersistedCategory("term")));
+
+            PersistedFeed feed = new PersistedFeed("feedName", "feedId");
+            entry.setFeed(feed);
+
+            feedRepository.saveEntry(entry);
         }
 
         @Test
-        public void shouldReturnFeedCategories() throws Exception {
+        public void shouldAlsoCreateFeed() throws Exception {
+            final Collection<PersistedFeed> feeds = feedRepository.getAllFeeds();
+            assertEquals(1, feeds.size());
+            final PersistedFeed feed = feeds.iterator().next();
+            assertEquals("feedName", feed.getName());
+            assertEquals("feedId", feed.getFeedId());
+        }
+
+        @Test
+        public void shouldFindEntry() throws Exception {
+            final PersistedEntry entry = feedRepository.getEntry("entryId", "feedName");
+            assertEquals("entryId", entry.getEntryId());
+        }
+
+        @Test
+        public void shouldCreateCategories() {
+            feedRepository.performSimpleAction(new SimpleSessionAction() {
+                @Override
+                public void perform(Session liveSession) {
+                    final PersistedEntry entry = (PersistedEntry) liveSession.createCriteria(PersistedEntry.class)
+                        .add(Restrictions.idEq("entryId")).add(Restrictions.eq("feed.name", "feedName")).uniqueResult();
+                    assertEquals(1, entry.getCategories().size());
+                    final PersistedCategory category = entry.getCategories().iterator().next();
+                    assertEquals("term", category.getTerm());
+                }
+            });
+        }
+
+        @Test
+        public void shouldFindEntryInFeed() throws Exception {
+            feedRepository.performSimpleAction(new SimpleSessionAction() {
+                @Override
+                public void perform(Session liveSession) {
+                    final List feeds = liveSession.createCriteria(PersistedFeed.class).list();
+                    final PersistedFeed feed = (PersistedFeed) feeds.iterator().next();
+                    assertEquals(1, feed.getEntries().size());
+                    final PersistedEntry entry = feed.getEntries().iterator().next();
+                    assertEquals("entryId", entry.getEntryId());
+                }
+            });
+        }
+    }
+
+    public static class WhenGettingCategories {
+        static HibernateFeedRepository feedRepository;
+        static Set<PersistedCategory> categories;
+
+        @BeforeClass
+        public static void setup() throws Exception {
+            Map<String, String> parameters = new HashMap<String, String>();
+            parameters.put("hibernate.connection.driver_class", "org.h2.Driver");
+            parameters.put("hibernate.connection.url", "jdbc:h2:mem:WhenGettingCategories");
+            parameters.put("hibernate.dialect", "org.hibernate.dialect.H2Dialect");
+            parameters.put("hibernate.connection.username", "sa");
+            parameters.put("hibernate.connection.password", "");
+            parameters.put("hibernate.hbm2ddl.auto", "update");
+
+            feedRepository = new HibernateFeedRepository(parameters);
+
+            PersistedEntry entry1 = new PersistedEntry("entryId1");
+            PersistedCategory cat1 = new PersistedCategory("cat1");
+            PersistedCategory cat2 = new PersistedCategory("cat2");
+            entry1.setCategories(new HashSet<PersistedCategory>(Arrays.asList(cat1, cat2)));
+
+            PersistedEntry entry2 = new PersistedEntry("entryId2");
+            PersistedCategory cat3 = new PersistedCategory("cat3");
+            entry2.setCategories(Collections.singleton(cat3));
+
+            PersistedFeed feed = new PersistedFeed("feedName", "feedId");
+            for (PersistedEntry entry : new PersistedEntry[] { entry1, entry2 }) {
+                entry.setFeed(feed);
+                feedRepository.saveEntry(entry);
+            }
+
+            categories = feedRepository.getCategoriesForFeed("feedName");
+            for (PersistedCategory category : categories) {
+                System.out.println(category.getTerm());
+            }
+        }
+
+        @Test
+        public void shouldContainExpectedCategories() throws Exception {
+            assertTrue(categories.containsAll(Arrays.asList(
+                new PersistedCategory("cat1"), new PersistedCategory("cat2"), new PersistedCategory("cat3")
+            )));
+        }
+
+        @Test
+        public void shouldNotContainOtherCategories() throws Exception {
+            assertEquals(3, categories.size());
 
         }
     }

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -31,7 +31,7 @@
                     the version of the *software* that is the subject of the document is indicated within each document:
                     look for <releaseinfo> near <pubdate>, both in the <info> section
                     1.1.0 of the plugin is compatible with Maven 2 for inclusion in the Jenkins build & color-formats sample code -->
-                <version>1.6.1</version>
+                <version>1.15.0</version>
                 <executions>
                     <execution>
                         <id>doc</id>

--- a/pom.xml
+++ b/pom.xml
@@ -420,7 +420,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
-                    <version>2.1.1</version>
+                    <version>2.6</version>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
Adding multiple entries with the same new criterion fails for us with the Hibernate adapter, since each transaction sees that the criterion is missing and tries to create it, after which all but one of the transactions fail due to the criterion now being present. Retrying in case of error solves this, as each retry  should have created at least one of the categories, ensuring that we are making progress. The number of retries is limited to the number of criteria to ensure that we eventually do fail if the root cause is something else.
An earlier version of this patch only performed retries when encountering a failure due to a constraint violation. This has been changed to perform retries on any kind of failures, as the concurrent writes can manifest themselves are other types of errors as well. Specifically, we got lock timeout errors in other transactions when the transaction that wrote first stalled before completing the commit.