### PR TITLE
Feature/marker pagination fixes

### DIFF
--- a/adapters/hibernate/src/main/java/org/atomhopper/hibernate/HibernateFeedRepository.java
+++ b/adapters/hibernate/src/main/java/org/atomhopper/hibernate/HibernateFeedRepository.java
@@ -162,13 +162,13 @@ public class HibernateFeedRepository implements FeedRepository {
 
                 switch (direction) {
                     case FORWARD:
-                        criteria.add(Restrictions.gt(DATE_LAST_UPDATED, markerEntry.getCreationDate())).addOrder(Order.asc(DATE_LAST_UPDATED));
+                        criteria.add(Restrictions.gt(DATE_LAST_UPDATED, markerEntry.getDateLastUpdated())).addOrder(Order.asc(DATE_LAST_UPDATED));
                         feedPage.addAll(criteria.list());
                         Collections.reverse(feedPage);
                         break;
 
                     case BACKWARD:
-                        criteria.add(Restrictions.le(DATE_LAST_UPDATED, markerEntry.getCreationDate())).addOrder(Order.desc(DATE_LAST_UPDATED));
+                        criteria.add(Restrictions.le(DATE_LAST_UPDATED, markerEntry.getDateLastUpdated())).addOrder(Order.desc(DATE_LAST_UPDATED));
                         feedPage.addAll(criteria.list());
                         break;
                 }

--- a/adapters/hibernate/src/main/java/org/atomhopper/hibernate/HibernateFeedRepository.java
+++ b/adapters/hibernate/src/main/java/org/atomhopper/hibernate/HibernateFeedRepository.java
@@ -259,6 +259,8 @@ public class HibernateFeedRepository implements FeedRepository {
 
                         if (feed == null) {
                             feed = entry.getFeed();
+                        } else {
+                            liveSession.lock(feed, LockMode.PESSIMISTIC_WRITE);
                         }
 
                         if (entry.getCreationDate() == null || entry.getDateLastUpdated() == null) {

--- a/adapters/hibernate/src/main/java/org/atomhopper/hibernate/HibernateFeedRepository.java
+++ b/adapters/hibernate/src/main/java/org/atomhopper/hibernate/HibernateFeedRepository.java
@@ -1,5 +1,7 @@
 package org.atomhopper.hibernate;
 
+import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -18,10 +20,13 @@ import org.atomhopper.hibernate.actions.ComplexSessionAction;
 import org.atomhopper.hibernate.actions.SimpleSessionAction;
 import org.atomhopper.hibernate.query.CategoryCriteriaGenerator;
 import org.hibernate.Criteria;
+import org.hibernate.LockMode;
+import org.hibernate.Query;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Restrictions;
+import org.hibernate.type.TimestampType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -254,6 +259,18 @@ public class HibernateFeedRepository implements FeedRepository {
 
                         if (feed == null) {
                             feed = entry.getFeed();
+                        }
+
+                        if (entry.getCreationDate() == null || entry.getDateLastUpdated() == null) {
+                            final Instant now = ((Timestamp)liveSession.createQuery(
+                                "select coalesce(max(current_timestamp()), current_timestamp()) from PersistedFeed"
+                            ).uniqueResult()).toInstant();
+                            if (entry.getCreationDate() == null) {
+                                entry.setCreationDate(now);
+                            }
+                            if (entry.getDateLastUpdated() == null) {
+                                entry.setDateLastUpdated(now);
+                            }
                         }
 
                         liveSession.saveOrUpdate(feed);

--- a/adapters/hibernate/src/main/java/org/atomhopper/hibernate/adapter/HibernateFeedPublisher.java
+++ b/adapters/hibernate/src/main/java/org/atomhopper/hibernate/adapter/HibernateFeedPublisher.java
@@ -106,10 +106,10 @@ public class HibernateFeedPublisher implements FeedPublisher {
         persistedEntry.setFeed(feedRef);
         persistedEntry.setEntryBody(entryToString(abderaParsedEntry));
 
+        feedRepository.saveEntry(persistedEntry);
+
         abderaParsedEntry.setUpdated(Date.from(persistedEntry.getDateLastUpdated()));
         abderaParsedEntry.setPublished(Date.from(persistedEntry.getCreationDate()));
-
-        feedRepository.saveEntry(persistedEntry);
 
         incrementCounterForFeed(postEntryRequest.getFeedName());
 

--- a/adapters/hibernate/src/main/java/org/atomhopper/hibernate/adapter/HibernateFeedPublisher.java
+++ b/adapters/hibernate/src/main/java/org/atomhopper/hibernate/adapter/HibernateFeedPublisher.java
@@ -91,8 +91,8 @@ public class HibernateFeedPublisher implements FeedPublisher {
             Date updated = abderaParsedEntry.getUpdated();
 
             if (updated != null) {
-                persistedEntry.setDateLastUpdated(updated);
-                persistedEntry.setCreationDate(updated);
+                persistedEntry.setDateLastUpdated(updated.toInstant());
+                persistedEntry.setCreationDate(updated.toInstant());
             }
         }
 
@@ -106,8 +106,8 @@ public class HibernateFeedPublisher implements FeedPublisher {
         persistedEntry.setFeed(feedRef);
         persistedEntry.setEntryBody(entryToString(abderaParsedEntry));
 
-        abderaParsedEntry.setUpdated(persistedEntry.getDateLastUpdated());
-        abderaParsedEntry.setPublished(persistedEntry.getCreationDate());
+        abderaParsedEntry.setUpdated(Date.from(persistedEntry.getDateLastUpdated()));
+        abderaParsedEntry.setPublished(Date.from(persistedEntry.getCreationDate()));
 
         feedRepository.saveEntry(persistedEntry);
 

--- a/adapters/hibernate/src/main/java/org/atomhopper/hibernate/adapter/HibernateFeedSource.java
+++ b/adapters/hibernate/src/main/java/org/atomhopper/hibernate/adapter/HibernateFeedSource.java
@@ -4,6 +4,7 @@ import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.sql.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -163,8 +164,8 @@ public class HibernateFeedSource implements FeedSource {
         if (hydratedEntryDocument != null) {
             entry = hydratedEntryDocument.getRoot();
 
-            entry.setUpdated(persistedEntry.getDateLastUpdated());
-            entry.setPublished(persistedEntry.getCreationDate());
+            entry.setUpdated(Date.from(persistedEntry.getDateLastUpdated()));
+            entry.setPublished(Date.from(persistedEntry.getCreationDate()));
         }
 
         return entry;

--- a/adapters/hibernate/src/test/java/org/atomhopper/hibernate/HibernateFeedRepositoryTest.java
+++ b/adapters/hibernate/src/test/java/org/atomhopper/hibernate/HibernateFeedRepositoryTest.java
@@ -1,7 +1,5 @@
 package org.atomhopper.hibernate;
 
-import static org.mockito.Mockito.mock;
-
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 
@@ -20,8 +18,6 @@ import java.util.concurrent.CyclicBarrier;
 import org.atomhopper.adapter.jpa.PersistedCategory;
 import org.atomhopper.adapter.jpa.PersistedEntry;
 import org.atomhopper.adapter.jpa.PersistedFeed;
-import org.atomhopper.dbal.AtomDatabaseException;
-import org.atomhopper.hibernate.actions.ComplexSessionAction;
 import org.atomhopper.hibernate.actions.SimpleSessionAction;
 import org.hibernate.Session;
 import org.hibernate.criterion.Restrictions;
@@ -39,11 +35,8 @@ import org.junit.runner.RunWith;
 @RunWith(Enclosed.class)
 public class HibernateFeedRepositoryTest {
 
-    public static class WhenPerformingSimpleAction {
-
-        HibernateFeedRepository feedRepository;
+    public static class WhenCreatingMisconfiguredFeedRepository{
         Map<String, String> parameters;
-        SimpleSessionAction simpleSessionAction;
 
         @Before
         public void setup() throws Exception {
@@ -54,40 +47,11 @@ public class HibernateFeedRepositoryTest {
             parameters.put("hibernate.connection.username", "sa");
             parameters.put("hibernate.connection.password", "");
             parameters.put("hibernate.hbm2ddl.auto", "update");
-
-            feedRepository = new HibernateFeedRepository(parameters);
-            simpleSessionAction = mock(SimpleSessionAction.class);
         }
 
-        @Test(expected=AtomDatabaseException.class)
+        @Test(expected=UnsupportedOperationException.class)
         public void shouldThrowAtomDatabaseException() throws Exception {
-            feedRepository.performSimpleAction(simpleSessionAction);
-        }
-    }
-
-    public static class WhenPerformingComplexAction {
-
-        HibernateFeedRepository feedRepository;
-        Map<String, String> parameters;
-        ComplexSessionAction complexSessionAction;
-
-        @Before
-        public void setup() throws Exception {
-            parameters = new HashMap<String, String>();
-            parameters.put("hibernate.connection.driver_class", "org.h2.Driver");
-            parameters.put("hibernate.dialect", "org.hibernate.dialect.H2Dialect");
-            parameters.put("hibernate.connection.username", "sa");
-            parameters.put("hibernate.connection.password", "");
-            parameters.put("hibernate.hbm2ddl.auto", "update");
-
-            feedRepository = new HibernateFeedRepository(parameters);
-            complexSessionAction = mock(ComplexSessionAction.class);
-        }
-
-        /*This should throw the error because */
-        @Test(expected=AtomDatabaseException.class)
-        public void shouldThrowAtomDatabaseException() throws Exception {
-            feedRepository.performComplexAction(complexSessionAction);
+            new HibernateFeedRepository(parameters);
         }
     }
 

--- a/adapters/hibernate/src/test/java/org/atomhopper/hibernate/HibernateFeedRepositoryTest.java
+++ b/adapters/hibernate/src/test/java/org/atomhopper/hibernate/HibernateFeedRepositoryTest.java
@@ -170,6 +170,7 @@ public class HibernateFeedRepositoryTest {
             PersistedEntry entry1 = new PersistedEntry("entry1");
             Instant earlier = Instant.now().minusSeconds(60);
             entry1.setDateLastUpdated(earlier);
+            entry1.setCreationDate(earlier);
             entry1.setFeed(feed);
 
             feedRepository.saveEntry(entry1);
@@ -177,6 +178,7 @@ public class HibernateFeedRepositoryTest {
             PersistedEntry entry2 = new PersistedEntry("entry2");
             Instant now = Instant.now();
             entry2.setDateLastUpdated(now);
+            entry2.setCreationDate(now);
             entry2.setFeed(feed);
 
             feedRepository.saveEntry(entry2);

--- a/adapters/hibernate/src/test/java/org/atomhopper/hibernate/adapter/HibernateFeedSourceTest.java
+++ b/adapters/hibernate/src/test/java/org/atomhopper/hibernate/adapter/HibernateFeedSourceTest.java
@@ -1,6 +1,7 @@
 package org.atomhopper.hibernate.adapter;
 
 import java.net.URL;
+import java.time.Instant;
 import java.util.*;
 
 import static junit.framework.Assert.assertEquals;
@@ -72,6 +73,9 @@ public class HibernateFeedSourceTest {
             persistedEntry.setFeed(persistedFeed);
             persistedEntry.setEntryId(ID);
             persistedEntry.setEntryBody(ENTRY_BODY);
+            Instant now = Instant.now();
+            persistedEntry.setCreationDate(now);
+            persistedEntry.setDateLastUpdated(now);
         }
 
         @Test(expected = UnsupportedOperationException.class)

--- a/adapters/migration/src/main/java/org/atomhopper/migration/adapter/MigrationFeedPublisher.java
+++ b/adapters/migration/src/main/java/org/atomhopper/migration/adapter/MigrationFeedPublisher.java
@@ -15,8 +15,10 @@ import org.atomhopper.response.EmptyBody;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Calendar;
 import java.util.Date;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.UUID;
 
 public class MigrationFeedPublisher implements FeedPublisher {
@@ -59,8 +61,6 @@ public class MigrationFeedPublisher implements FeedPublisher {
     @Override
     public AdapterResponse<Entry> postEntry(PostEntryRequest postEntryRequest) {
 
-        PersistedEntry entry = new PersistedEntry();
-
         // If allowOverrideId is false then set the Id
         // Also set the id if allowOverrideId is true, but no Id was sent in the entry
         if (!allowOverrideId || postEntryRequest.getEntry().getId() == null || StringUtils.isBlank(postEntryRequest.getEntry().getId().toString().trim())) {
@@ -70,7 +70,10 @@ public class MigrationFeedPublisher implements FeedPublisher {
         // If allowOverrideDate is false then set the DateLastUpdated
         // Also set the DateLastUpdated if allowOverrideDate is true, but no DateLastUpdated was sent in the entry
         if (!allowOverrideDate || postEntryRequest.getEntry().getUpdated() == null) {
-            postEntryRequest.getEntry().setUpdated(Date.from(entry.getDateLastUpdated()));
+            final Calendar localNow = Calendar.getInstance(TimeZone.getDefault());
+            localNow.setTimeInMillis(System.currentTimeMillis());
+
+            postEntryRequest.getEntry().setUpdated(localNow.getTime());
         }
 
         switch (writeTo) {

--- a/adapters/migration/src/main/java/org/atomhopper/migration/adapter/MigrationFeedPublisher.java
+++ b/adapters/migration/src/main/java/org/atomhopper/migration/adapter/MigrationFeedPublisher.java
@@ -15,6 +15,7 @@ import org.atomhopper.response.EmptyBody;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Date;
 import java.util.Map;
 import java.util.UUID;
 
@@ -69,7 +70,7 @@ public class MigrationFeedPublisher implements FeedPublisher {
         // If allowOverrideDate is false then set the DateLastUpdated
         // Also set the DateLastUpdated if allowOverrideDate is true, but no DateLastUpdated was sent in the entry
         if (!allowOverrideDate || postEntryRequest.getEntry().getUpdated() == null) {
-            postEntryRequest.getEntry().setUpdated(entry.getDateLastUpdated());
+            postEntryRequest.getEntry().setUpdated(Date.from(entry.getDateLastUpdated()));
         }
 
         switch (writeTo) {

--- a/hopper/pom.xml
+++ b/hopper/pom.xml
@@ -30,7 +30,12 @@
             <artifactId>hibernate-core</artifactId>
         </dependency>
 
-        <dependency>
+      <dependency>
+        <groupId>org.hibernate</groupId>
+        <artifactId>hibernate-java8</artifactId>
+      </dependency>
+
+      <dependency>
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
         </dependency>

--- a/hopper/src/main/java/org/atomhopper/adapter/jpa/PersistedEntry.java
+++ b/hopper/src/main/java/org/atomhopper/adapter/jpa/PersistedEntry.java
@@ -18,9 +18,15 @@ import javax.persistence.Lob;
 import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 
 @Entity
-@Table(name = "Entries")
+@Table(
+    name = "Entries", uniqueConstraints = {
+        @UniqueConstraint(columnNames= {"Feed", "CreationDate"}),
+        @UniqueConstraint(columnNames= {"Feed", "DateLastUpdated"})
+    }
+)
 public class PersistedEntry implements Serializable {
 
     @Id

--- a/hopper/src/main/java/org/atomhopper/adapter/jpa/PersistedEntry.java
+++ b/hopper/src/main/java/org/atomhopper/adapter/jpa/PersistedEntry.java
@@ -1,5 +1,12 @@
 package org.atomhopper.adapter.jpa;
 
+import java.io.Serializable;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 import javax.persistence.Basic;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -12,15 +19,8 @@ import javax.persistence.Lob;
 import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
-import java.io.Serializable;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.TimeZone;
+
+import org.atomhopper.util.NanoClock;
 
 @Entity
 @Table(name = "Entries")
@@ -49,22 +49,18 @@ public class PersistedEntry implements Serializable {
     
     @Basic(optional = false)
     @Column(name = "CreationDate")
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date creationDate;
+    private Instant creationDate;
     
     @Basic(optional = false)
     @Column(name = "DateLastUpdated")
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date dateLastUpdated;
+    private Instant dateLastUpdated;
 
     public PersistedEntry() {
         categories = Collections.EMPTY_SET;
-        
-        final Calendar localNow = Calendar.getInstance(TimeZone.getDefault());
-        localNow.setTimeInMillis(System.currentTimeMillis());
-        
-        creationDate = localNow.getTime();
-        dateLastUpdated = localNow.getTime();
+        Clock nanoClock = new NanoClock();
+        Instant now = Instant.now(nanoClock);
+        creationDate = now;
+        dateLastUpdated = now;
     }
 
     public PersistedEntry(String entryId) {
@@ -74,20 +70,20 @@ public class PersistedEntry implements Serializable {
         this.entryId = entryId;
     }
 
-    public Date getCreationDate() {
-        return (Date) creationDate.clone();
+    public Instant getCreationDate() {
+        return creationDate;
     }
 
-    public void setCreationDate(Date creationDate) {
-        this.creationDate = (Date) creationDate.clone();
+    public void setCreationDate(Instant creationDate) {
+        this.creationDate = creationDate;
     }
 
-    public Date getDateLastUpdated() {
-        return (Date) dateLastUpdated.clone();
+    public Instant getDateLastUpdated() {
+        return dateLastUpdated;
     }
 
-    public void setDateLastUpdated(Date dateLastUpdated) {
-        this.dateLastUpdated = (Date) dateLastUpdated.clone();
+    public void setDateLastUpdated(Instant dateLastUpdated) {
+        this.dateLastUpdated = dateLastUpdated;
     }
 
     public Set<PersistedCategory> getCategories() {

--- a/hopper/src/main/java/org/atomhopper/adapter/jpa/PersistedEntry.java
+++ b/hopper/src/main/java/org/atomhopper/adapter/jpa/PersistedEntry.java
@@ -1,7 +1,6 @@
 package org.atomhopper.adapter.jpa;
 
 import java.io.Serializable;
-import java.time.Clock;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashSet;
@@ -19,8 +18,6 @@ import javax.persistence.Lob;
 import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
-
-import org.atomhopper.util.NanoClock;
 
 @Entity
 @Table(name = "Entries")
@@ -57,10 +54,6 @@ public class PersistedEntry implements Serializable {
 
     public PersistedEntry() {
         categories = Collections.EMPTY_SET;
-        Clock nanoClock = new NanoClock();
-        Instant now = Instant.now(nanoClock);
-        creationDate = now;
-        dateLastUpdated = now;
     }
 
     public PersistedEntry(String entryId) {

--- a/hopper/src/main/java/org/atomhopper/util/NanoClock.java
+++ b/hopper/src/main/java/org/atomhopper/util/NanoClock.java
@@ -1,0 +1,49 @@
+package org.atomhopper.util;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+public class NanoClock extends Clock
+{
+    private final Clock clock;
+
+    private final long initialNanos;
+
+    private final Instant initialInstant;
+
+    public NanoClock()
+    {
+        this(Clock.systemUTC());
+    }
+
+    public NanoClock(final Clock clock)
+    {
+        this.clock = clock;
+        initialInstant = clock.instant();
+        initialNanos = getSystemNanos();
+    }
+
+    @Override
+    public ZoneId getZone()
+    {
+        return clock.getZone();
+    }
+
+    @Override
+    public Instant instant()
+    {
+        return initialInstant.plusNanos(getSystemNanos() - initialNanos);
+    }
+
+    @Override
+    public Clock withZone(final ZoneId zone)
+    {
+        return new NanoClock(clock.withZone(zone));
+    }
+
+    private long getSystemNanos()
+    {
+        return System.nanoTime();
+    }
+}

--- a/hopper/src/test/java/org/atomhopper/adapter/jpa/PersistedEntryTest.java
+++ b/hopper/src/test/java/org/atomhopper/adapter/jpa/PersistedEntryTest.java
@@ -50,6 +50,8 @@ public class PersistedEntryTest {
         @Before
         public void setUp() throws Exception {
             persistedEntry = new PersistedEntry();
+            persistedEntry.setCreationDate(Instant.now());
+            persistedEntry.setDateLastUpdated(Instant.now());
         }
 
         @Test

--- a/hopper/src/test/java/org/atomhopper/adapter/jpa/PersistedEntryTest.java
+++ b/hopper/src/test/java/org/atomhopper/adapter/jpa/PersistedEntryTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -44,7 +44,7 @@ public class PersistedEntryTest {
     public static class WhenAccessingPersistedEntries {
 
         private PersistedEntry persistedEntry;
-        private Date date;
+        private Instant date;
         private Set<PersistedCategory> persistedCategories;
 
         @Before
@@ -57,7 +57,7 @@ public class PersistedEntryTest {
             assertNotNull("Getting creation date should not return null.", persistedEntry.getCreationDate());
             date = persistedEntry.getCreationDate();
             assertEquals("Getting creation date should return a Date object.", persistedEntry.getCreationDate(), date);
-            persistedEntry.setCreationDate(new Date());
+            persistedEntry.setCreationDate(Instant.now());
             assertNotSame("Setting the creation date should update the object.", persistedEntry.getCreationDate(), date);
         }
 
@@ -66,7 +66,7 @@ public class PersistedEntryTest {
             assertNotNull("Getting the date last updated should not return null.", persistedEntry.getDateLastUpdated());
             date = persistedEntry.getDateLastUpdated();
             assertEquals("Getting the date last updated should return a date object.", persistedEntry.getDateLastUpdated(), date);
-            persistedEntry.setDateLastUpdated(new Date());
+            persistedEntry.setDateLastUpdated(Instant.now());
             assertNotSame("Setting the date last updated should change last updated date.", persistedEntry.getDateLastUpdated(), date);
         }
 

--- a/hopper/src/test/java/org/atomhopper/adapter/jpa/PersistedEntryTest.java
+++ b/hopper/src/test/java/org/atomhopper/adapter/jpa/PersistedEntryTest.java
@@ -67,7 +67,7 @@ public class PersistedEntryTest {
             date = persistedEntry.getDateLastUpdated();
             assertEquals("Getting the date last updated should return a date object.", persistedEntry.getDateLastUpdated(), date);
             persistedEntry.setDateLastUpdated(new Date());
-            assertNotSame("Setting the date last updated should change last updated date.", persistedEntry.getDateLastUpdated().equals(date));
+            assertNotSame("Setting the date last updated should change last updated date.", persistedEntry.getDateLastUpdated(), date);
         }
 
         @Test

--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,14 @@
                 <version>1.6.5</version>
             </dependency>
 
-            <dependency>
+
+          <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.6.5</version>
+          </dependency>
+
+          <dependency>
                 <groupId>commons-httpclient</groupId>
                 <artifactId>commons-httpclient</artifactId>
                 <version>3.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -407,8 +407,8 @@
                     <version>2.3.2</version>
 
                     <configuration>
-                        <source>1.6</source>
-                        <target>1.6</target>
+                        <source>1.8</source>
+                        <target>1.8</target>
                     </configuration>
                 </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -94,16 +94,22 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-core</artifactId>
-                <version>4.1.3.Final</version>
+                <version>5.1.1.Final</version>
             </dependency>
 
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-c3p0</artifactId>
-                <version>4.1.3.Final</version>
+                <version>5.1.1.Final</version>
             </dependency>
 
-            <dependency>
+          <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-java8</artifactId>
+            <version>5.1.1.Final</version>
+          </dependency>
+
+          <dependency>
                 <groupId>org.javassist</groupId>
                 <artifactId>javassist</artifactId>
                 <version>3.16.1-GA</version>

--- a/test-suite/src/main/java/org/atomhopper/jetty/AtomHopperJettyServerBuilder.java
+++ b/test-suite/src/main/java/org/atomhopper/jetty/AtomHopperJettyServerBuilder.java
@@ -9,16 +9,19 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.springframework.web.context.ContextLoaderListener;
 
-/**
- *
- *
- */
+
 public class AtomHopperJettyServerBuilder {
 
     private final int portNumber;
+    private String configurationPathAndFile = "";
 
     public AtomHopperJettyServerBuilder(int portNumber) {
         this.portNumber = portNumber;
+    }
+
+    public AtomHopperJettyServerBuilder(int portNumber, String configurationPathAndFile) {
+        this.portNumber = portNumber;
+        this.configurationPathAndFile = configurationPathAndFile;
     }
 
     private Server buildNewInstance() {
@@ -28,7 +31,11 @@ public class AtomHopperJettyServerBuilder {
         final ServletHolder atomHopServer = new ServletHolder(AtomHopperServlet.class);
         final ServletHolder versionServlet = new ServletHolder(AtomHopperVersionServlet.class);
         atomHopServer.setInitParameter(ServletInitParameter.CONTEXT_ADAPTER_CLASS.toString(), ServletSpringContext.class.getName());
-        atomHopServer.setInitParameter(ServletInitParameter.CONFIGURATION_LOCATION.toString(), "classpath:/META-INF/atom-server.cfg.xml");
+        if(configurationPathAndFile.length() <= 0) {
+            atomHopServer.setInitParameter(ServletInitParameter.CONFIGURATION_LOCATION.toString(), "classpath:/META-INF/atom-server.cfg.xml");
+        } else {
+            atomHopServer.setInitParameter(ServletInitParameter.CONFIGURATION_LOCATION.toString(), configurationPathAndFile);
+        }
 
         rootContext.addServlet(versionServlet, "/buildinfo");
         rootContext.addServlet(atomHopServer, "/*");

--- a/test-suite/src/test/java/org/atomhopper/FeedForwardBackwardTest.java
+++ b/test-suite/src/test/java/org/atomhopper/FeedForwardBackwardTest.java
@@ -1,5 +1,16 @@
 package org.atomhopper;
 
+import static java.util.stream.Collectors.toList;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.fail;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.abdera.Abdera;
 import org.apache.abdera.model.Document;
@@ -16,102 +27,120 @@ import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
-
-import static junit.framework.Assert.assertEquals;
-
-
 @RunWith(Enclosed.class)
 public class FeedForwardBackwardTest extends JettyIntegrationTestHarness {
 
     private static final HttpClient httpClient = new HttpClient();
     private static final String urlAndPort = "http://localhost:" + getPort();
     private static Abdera abdera = null;
-    
+
     public static synchronized Abdera getInstance() {
         if (abdera == null) {
             abdera = new Abdera();
         }
         return abdera;
-    }    
+    }
 
     public static PostMethod newPostEntryMethod(String content) {
         final PostMethod post = new PostMethod(getURL());
         post.addRequestHeader(new Header("content-type", "application/atom+xml"));
-        post.setRequestBody("<?xml version=\"1.0\" ?><entry xmlns=\"http://www.w3.org/2005/Atom\"><author><name>Chad</name></author><content>" + content + "</content></entry>");
+        post.setRequestBody(
+            "<?xml version=\"1.0\" ?><entry xmlns=\"http://www"
+                + ".w3.org/2005/Atom\"><author><name>Chad</name></author><content>"
+                + content + "</content></entry>");
 
         return post;
     }
-    
+
     public static String getURL() {
         return urlAndPort + "/namespace3/feed3/";
     }
-    
+
     public static GetMethod getFeedMethod() {
         return new GetMethod(getURL());
-    }    
-    
+    }
+
     public static String getFeedDirectionForwardMethod(String markerId) {
         return getURL() + "?marker=" + markerId + "&direction=forward&limit=10";
-    }  
-    
+    }
+
     public static String getFeedDirectionBackwardMethod(String markerId) {
         return getURL() + "?marker=" + markerId + "&direction=backward&limit=10";
-    } 
-    
+    }
+
     public static class WhenRequestingFeed {
         @Test
         public void shouldOrderCorrectlyForwardAndBackward() throws Exception {
-            final HttpMethod getFeedMethod = getFeedMethod();
-            assertEquals("Hitting Atom Hopper with an empty datastore should return a 200", HttpStatus.SC_OK, httpClient.executeMethod(getFeedMethod));            
-            // Create 20 new entries
-            for(int i = 1; i < 21; i++) {
-                final HttpMethod postMethod = newPostEntryMethod("<order>" + Integer.toString(i) + "</order>");
-                assertEquals("Creating a new entry should return a 201", HttpStatus.SC_CREATED, httpClient.executeMethod(postMethod));
-            }
-            
-            // namespace3/feed3
-            assertEquals("Getting a feed should return a 200", HttpStatus.SC_OK, httpClient.executeMethod(getFeedMethod));
-
-            // A bit verbose, but it checks the forward and backward direction of the feed
             Parser parser = getInstance().getParser();
             URL url = new URL(getURL());
-            Document<Feed> doc = parser.parse(url.openStream(), url.toString());
-            Feed feed = doc.getRoot();
-            List<String> idList = new ArrayList<String>();
- 
-            // Get the IDs in their default order
-            for (Entry entry : feed.getEntries()) {
-                idList.add(entry.getId().toString());
-            }
-            
-            if(!(idList.isEmpty())) {
-                int idCount = 0;
-                
-                // Check the feed backward with the first id as the marker
-                URL urlBackward = new URL(getFeedDirectionBackwardMethod(idList.get(0)));
-                Document<Feed> docBackward = parser.parse(urlBackward.openStream(), urlBackward.toString());
-                Feed feedBackward = docBackward.getRoot();
-                
-                for (Entry entry : feedBackward.getEntries()) {
-                    assertEquals("The entries should be in backward order", entry.getId().toString(), idList.get(idCount));
-                    idCount++;
-                }
-                
-                // Check the feed forward with the last id as the marker
-                URL urlForward = new URL(getFeedDirectionForwardMethod(idList.get(idList.size() - 1)));
-                Document<Feed> docForward = parser.parse(urlForward.openStream(), urlForward.toString());
-                Feed feedForward = docForward.getRoot();
-                // Adjust for the offset going forward
-                idCount = 9;
+            List<String> idsOfPostedEntries = new ArrayList<>();
 
-                for (Entry entry : feedForward.getEntries()) {
-                    assertEquals("The entries should be in forward order", entry.getId().toString(), idList.get(idCount));
-                    idCount++;
-                }
+            final HttpMethod getFeedMethod = getFeedMethod();
+            assertEquals("Hitting Atom Hopper with an empty datastore should return a 200", HttpStatus.SC_OK,
+                httpClient.executeMethod(getFeedMethod));
+            // Create 20 new entries
+            for (int i = 1; i < 21; i++) {
+                final HttpMethod postMethod = newPostEntryMethod("<order>" + Integer.toString(i) + "</order>");
+                assertEquals("Creating a new entry should return a 201", HttpStatus.SC_CREATED,
+                    httpClient.executeMethod(postMethod));
+                final Document<Entry> response = parser.parse(postMethod.getResponseBodyAsStream(), url.toString());
+                idsOfPostedEntries.add(response.getRoot().getId().toString());
+            }
+
+            // namespace3/feed3
+            assertEquals("Getting a feed should return a 200", HttpStatus.SC_OK,
+                httpClient.executeMethod(getFeedMethod));
+
+            // A bit verbose, but it checks the forward and backward direction of the feed
+            Document<Feed> doc = parser.parse(url.openStream(), url.toString());
+            List<Entry> entries = doc.getRoot().getEntries();
+            List<String> idList = entries.stream().map(e -> e.getId().toString()).collect(Collectors.toList());
+            assertTrue("All posted entries should be found in feed page", idList.containsAll(idsOfPostedEntries));
+            assertTrue("Feed page should only contain the posted entries", idsOfPostedEntries.containsAll(idList));
+            //entries.forEach(e -> System.out.printf("%s %s\n", e.getId(), e.getPublished().toInstant()));
+            for (int i = 1; i < entries.size(); i++) {
+                Entry first = entries.get(i-1);
+                Entry second = entries.get(i);
+                assertFalse(
+                    String.format(
+                        "Entry %s created at %s should be listed before entry %s created at %s",
+                        first, first.getPublished().toInstant(), second, second.getPublished().toInstant()
+                    ),
+                    first.getPublished().before(second.getPublished())
+                );
+            }
+
+            if (idList.isEmpty()) {
+                fail();
+            }
+
+            int idCount = 0;
+            final String marker = idList.get(0);
+            // Check the feed backward with the first id as the marker
+            URL urlBackward = new URL(getFeedDirectionBackwardMethod(marker));
+            Document<Feed> docBackward = parser.parse(urlBackward.openStream(), urlBackward.toString());
+            Feed feedBackward = docBackward.getRoot();
+            List<String> backwardIds = feedBackward.getEntries().stream().map(e->e.getId().toString()).collect(toList());
+
+            assertTrue("The backwards feed page should contain the marker", backwardIds.contains(marker));
+            assertEquals("The first entry should be the marker", marker, backwardIds.get(0));
+            assertTrue("The entries on the backwards page should all be known", idList.containsAll(backwardIds));
+            for (Entry entry : feedBackward.getEntries()) {
+                assertEquals("The entries should be in backward order", entry.getId().toString(), idList.get(idCount));
+                idCount++;
+            }
+
+            // Check the feed forward with the last id as the marker
+            URL urlForward = new URL(getFeedDirectionForwardMethod(idList.get(idList.size() - 1)));
+            Document<Feed> docForward = parser.parse(urlForward.openStream(), urlForward.toString());
+            Feed feedForward = docForward.getRoot();
+            // Adjust for the offset going forward
+            idCount = 9;
+
+            for (Entry entry : feedForward.getEntries()) {
+                assertEquals("The entries should be in forward order", entry.getId().toString(), idList.get(idCount));
+                idCount++;
             }
         }
-    }    
+    }
 }

--- a/test-suite/src/test/java/org/atomhopper/FeedTagTest.java
+++ b/test-suite/src/test/java/org/atomhopper/FeedTagTest.java
@@ -5,6 +5,8 @@ import org.apache.abdera.factory.Factory;
 import org.apache.abdera.model.Entry;
 import org.apache.abdera.model.Source;
 import org.apache.abdera.protocol.client.AbderaClient;
+import org.apache.abdera.protocol.client.ClientResponse;
+import org.apache.commons.httpclient.HttpStatus;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
@@ -124,9 +126,11 @@ public class FeedTagTest extends JettyIntegrationTestHarness {
             //entry.setUpdated(date); //This needs to be auto-generated.
 
             //report("The Entry to Post", entry.toString());  //Commented out to reduced build logs.
-            String postResponse = abderaClient.post("http://localhost:" + getPort() + "/namespace/feed/", entry).getDocument().getRoot().toString();
-            doc = xml.toDOM(postResponse);
-            //report("The Created Entry", postResponse);  //Commented out to reduced build logs.
+            ClientResponse postResponse = abderaClient.post("http://localhost:" + getPort() + "/namespace/feed/", entry);
+            String postResponseText = postResponse.getDocument().getRoot().toString();
+            //report("The Created Entry", postResponseText);  //Commented out to reduced build logs.
+            assertEquals(postResponse.getStatus(), HttpStatus.SC_CREATED);
+            doc = xml.toDOM(postResponseText);
         }
 
         @Test

--- a/test-suite/src/test/java/org/atomhopper/FollowByMarker.java
+++ b/test-suite/src/test/java/org/atomhopper/FollowByMarker.java
@@ -1,0 +1,121 @@
+package org.atomhopper;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.apache.abdera.Abdera;
+import org.apache.abdera.i18n.iri.IRI;
+import org.apache.abdera.model.Document;
+import org.apache.abdera.model.Entry;
+import org.apache.abdera.model.Feed;
+import org.apache.abdera.protocol.Response;
+import org.apache.abdera.protocol.client.AbderaClient;
+import org.apache.abdera.protocol.client.ClientResponse;
+import org.apache.abdera.protocol.client.RequestOptions;
+
+public class FollowByMarker implements Runnable {
+    private final String url;
+    private final String prefix;
+    private final Abdera abdera = new Abdera();
+    private final AbderaClient client;
+
+
+    public static void main(String[] args) throws IOException {
+        final String url = args.length >= 1 ? args[0] : "http://localhost:8080/namespace/feed";
+        final String prefix = args.length >= 2 ? args[1] : "fe3b98c9-d86a-4d93-afd5-c8d10c542882";
+
+        FollowByMarker followByMarker = new FollowByMarker(url, prefix);
+        followByMarker.run();
+    }
+
+    public FollowByMarker(String url, String prefix) {
+        this.url = url;
+        this.prefix = prefix;
+        client = new AbderaClient(abdera);
+    }
+
+    boolean shouldRun;
+    Thread thread;
+    IRI marker = null;
+    List<String> seen = new ArrayList<String>();
+
+    public Thread start(String name) {
+        shouldRun = true;
+        thread = new Thread(this, name);
+        thread.start();
+        return thread;
+    }
+
+    public List<String> stop() throws InterruptedException {
+        shouldRun = false;
+        thread.interrupt();
+        thread.join();
+        fetchOnce();
+        return seen;
+    }
+
+    public void run() {
+
+        System.out.println("Looking for first entry with prefix " + prefix + " on " + url);
+        while (shouldRun && marker == null) {
+            System.out.println("GET " + url);
+            ClientResponse resp = client.get(url + "?limit=1000", new RequestOptions(true));
+            if (resp.getType() == Response.ResponseType.SUCCESS) {
+                Document<Feed> doc = resp.getDocument();
+                System.out.println("Got " + doc.getRoot().getEntries().size() + " entries");
+                if (!doc.getRoot().getEntries().isEmpty()) {
+                    System.out.println("First title: " + doc.getRoot().getEntries().get(0).getTitle());
+                }
+                for (Entry entry : doc.getRoot().getEntries()) {
+                    if (!entry.getTitle().startsWith(prefix)) {
+                        continue;
+                    }
+                    if (marker == null) {
+                        marker = entry.getId();
+                    }
+                    seen.add(entry.getTitle());
+                }
+            } else {
+                System.out.println(resp.getType().name());
+            }
+        }
+
+        System.out.println("Starting at marker " + marker);
+
+        long lastPrintout = System.nanoTime();
+
+        while (shouldRun) {
+            long now = System.nanoTime();
+            if (now > lastPrintout + 1000000000) {
+                System.out.printf("%s: %d\n", new Date(), seen.size());
+                lastPrintout = now;
+            }
+
+            fetchOnce();
+        }
+    }
+
+    public void fetchOnce() {
+        String withMarker = url + "?marker=" + marker.toString();
+        //System.out.println("Fetching " + withMarker);
+        ClientResponse resp = client.get(withMarker, new RequestOptions(true));
+        if (resp.getType() == Response.ResponseType.SUCCESS) {
+            Document<Feed> doc = resp.getDocument();
+            final List<Entry> entries = doc.getRoot().getEntries();
+            if (entries.isEmpty()) {
+                return;
+            }
+            marker = entries.get(0).getId();
+            for (Entry entry : entries) {
+                if (!entry.getTitle().startsWith(prefix)) {
+                    continue;
+                }
+                seen.add(entry.getTitle());
+            }
+        } else {
+            System.out.println(resp.getType().name());
+        }
+    }
+}

--- a/test-suite/src/test/java/org/atomhopper/MarkerRaceConditionTest.java
+++ b/test-suite/src/test/java/org/atomhopper/MarkerRaceConditionTest.java
@@ -1,0 +1,136 @@
+package org.atomhopper;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.methods.PostMethod;
+import org.apache.commons.httpclient.methods.StringRequestEntity;
+import org.atomhopper.servlet.ServletInitParameter;
+import org.atomhopper.servlet.ServletSpringContext;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.springframework.web.context.ContextLoaderListener;
+
+public class MarkerRaceConditionTest {
+    public static void main(String[] args) throws Exception {
+        final int port = 8080;
+        final int numPosters = 20;
+        final int numEntries = 10000;
+
+        String url = "http://localhost:" + port + "/namespace/feed";
+        String prefix = UUID.randomUUID().toString();
+        String config = getResource("marker-race-condition/atom-server.cfg.xml");
+        String context = getResource("marker-race-condition/application-context-h2.xml");
+        System.setProperty("org.jboss.logging.provider", "slf4j");
+
+        Server serverInstance = buildNewInstance(port, config, context);
+        serverInstance.setStopAtShutdown(true);
+        serverInstance.start();
+
+        ensureFeedExists(url);
+
+        final FollowByMarker follower = new FollowByMarker(url, prefix);
+        follower.start("follower");
+
+        final AtomicInteger numPosted = new AtomicInteger();
+        final AtomicInteger numFailed = new AtomicInteger();
+        PostInParallel posters = new PostInParallel(url, prefix, numPosted, numFailed);
+        long postStart = System.nanoTime();
+        posters.run(numPosters, numEntries);
+        long postEnd = System.nanoTime();
+
+        List<String> seen = follower.stop();
+        Set<String> unique = new HashSet<String>(seen);
+        List<String> sorted = new ArrayList<String>(seen);
+        Collections.sort(sorted);
+        if (unique.size() != seen.size()) {
+            System.out.printf("Found %d duplicates\n", unique.size() - seen.size());
+            for (String s : unique) {
+                int start = Collections.binarySearch(sorted, s);
+                int pos = start;
+                while (pos < sorted.size() - 1 && sorted.get(pos+1).equals(s)) {
+                    pos++;
+                }
+                if ((pos - start) > 1) {
+                    System.out.printf("Found %d copies of %s\n", pos - start, s);
+                }
+            }
+        }
+
+        serverInstance.stop();
+
+        System.out.printf("Posting entries took %f ms\n", (postEnd - postStart) / 1000000.0);
+        System.out.printf("num posted: %d num failed: %d, num seen: %d\n", numPosted.get(), numFailed.get(), unique.size());
+
+        for (int poster = 0; poster < numPosters; poster++) {
+            for (int entry = 0; entry < numEntries; entry++) {
+                String title = String.format("%s-%s-%s", prefix, entry, poster);
+                if (Collections.binarySearch(sorted, title) < 0) {
+                    System.out.printf("Did not find %s\n", title);
+                }
+            }
+        }
+
+        System.exit(numPosted.get() == unique.size() ? 0 : 1);
+    }
+
+    private static String getResource(String resource) {
+        return MarkerRaceConditionTest.class.getClassLoader().getResource(resource).toString();
+    }
+
+    private static void ensureFeedExists(String url) {
+        boolean posted = false;
+        while (!posted) {
+            final PostMethod post = new PostMethod(url);
+            final String title = "[MarkerRaceConditionTest start]";
+            final String body = "<?xml version=\"1.0\" ?><entry xmlns=\"http://www.w3.org/2005/Atom\">"
+                + "<title>" + title + "</title>"
+                + "<content><p>" + title + "</p></content></entry>";
+            try {
+                post.setRequestEntity(new StringRequestEntity(body, "application/atom+xml", "ascii"));
+            } catch (UnsupportedEncodingException e) {
+                e.printStackTrace();
+            }
+
+            final HttpClient httpClient = new HttpClient();
+
+            try {
+                final int result = httpClient.executeMethod(post);
+                if (result != 201) {
+                    continue;
+                }
+                posted = true;
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private static Server buildNewInstance(int portNumber, String configurationPathAndFile, String applicationContext) {
+        final Server server = new Server(portNumber);
+        final ServletContextHandler servletContext = new ServletContextHandler(server, "/");
+        servletContext.getInitParams().put("contextConfigLocation", applicationContext);
+        servletContext.addEventListener(new ContextLoaderListener());
+
+        final ServletHolder atomHopServer = new ServletHolder(AtomHopperServlet.class);
+        atomHopServer.setInitParameter(
+            ServletInitParameter.CONTEXT_ADAPTER_CLASS.toString(), ServletSpringContext.class.getName()
+        );
+        atomHopServer.setInitParameter(
+            ServletInitParameter.CONFIGURATION_LOCATION.toString(), configurationPathAndFile
+        );
+
+        servletContext.addServlet(atomHopServer, "/*");
+
+        return server;
+    }
+}

--- a/test-suite/src/test/java/org/atomhopper/PostInParallel.java
+++ b/test-suite/src/test/java/org/atomhopper/PostInParallel.java
@@ -1,0 +1,122 @@
+package org.atomhopper;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.Date;
+import java.util.UUID;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.methods.PostMethod;
+import org.apache.commons.httpclient.methods.StringRequestEntity;
+
+public class PostInParallel {
+    private final String url;
+    private final String prefix;
+    private final AtomicInteger numPosted;
+    private final AtomicInteger numFailed;
+
+    public static void main(String[] args) throws IOException, InterruptedException {
+        final String url = args.length >= 1 ? args[0] : "http://localhost:8080/namespace/feed";
+        final String prefix = args.length >= 2 ? args[1] : UUID.randomUUID().toString();
+        final AtomicInteger numPosted = new AtomicInteger();
+        final AtomicInteger numFailed = new AtomicInteger();
+
+        Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+            @Override
+            public void run() {
+                System.out.println("Total posted: " + numPosted.longValue());
+                System.out.println("Total failed: " + numFailed.longValue());
+            }
+        }));
+
+
+        final int numParallel = 10;
+
+        new PostInParallel(url, prefix, numPosted, numFailed).run(numParallel, 10000);
+    }
+
+    public PostInParallel(String url, String prefix, AtomicInteger numPosted, AtomicInteger numFailed) {
+        this.url = url;
+        this.prefix = prefix;
+        this.numPosted = numPosted;
+        this.numFailed = numFailed;
+    }
+
+    public void run(int numParallel, int numBatches) throws InterruptedException {
+        final CyclicBarrier barrier = new CyclicBarrier(numParallel);
+        Thread threads[] = new Thread[numParallel];
+        for (int i = 0; i < numParallel; i++) {
+            final int threadid = i;
+            threads[i] = new Thread(new PostEntries(threadid, barrier, numBatches), String.format("poster-%d", threadid));
+        }
+        for (Thread t : threads) {
+            t.start();
+        }
+        for (Thread t : threads) {
+            t.join();
+        }
+    }
+
+    private class PostEntries implements Runnable {
+        private final int threadid;
+        private final CyclicBarrier barrier;
+        private final int numBatches;
+
+        public PostEntries(int threadid, CyclicBarrier barrier, int numBatches) {
+            this.threadid = threadid;
+            this.barrier = barrier;
+            this.numBatches = numBatches;
+        }
+
+        @Override
+        public void run() {
+            final HttpClient httpClient = new HttpClient();
+
+            for (int batch = 0; batch < numBatches; batch++) {
+                final String title = prefix + "-" + batch + "-" + threadid;
+                final String body = "<?xml version=\"1.0\" ?><entry xmlns=\"http://www.w3.org/2005/Atom\">"
+                    + "<title>" + title + "</title>"
+                    + "</entry>";
+
+                try {
+                    barrier.await();
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                } catch (BrokenBarrierException e) {
+                    e.printStackTrace();
+                }
+
+                boolean posted = false;
+                while (!posted) {
+                    final PostMethod post = new PostMethod(url);
+                    try {
+                        post.setRequestEntity(new StringRequestEntity(body, "application/atom+xml", "ascii"));
+                    } catch (UnsupportedEncodingException e) {
+                        e.printStackTrace();
+                    }
+                    try {
+                        final int result = httpClient.executeMethod(post);
+                        if (result != 201) {
+                            numFailed.incrementAndGet();
+                            System.err.println("Failed to POST entry: " + body);
+                            continue;
+                        }
+                    } catch (Exception e) {
+                        numFailed.incrementAndGet();
+                        System.err.println("Error when trying to POST entry: " + e);
+                        e.printStackTrace();
+                    }
+                    posted = true;
+                }
+                int postnum = numPosted.incrementAndGet();
+                if (postnum % 1000 == 0) {
+                    System.out.printf("%s: %d\n", new Date(), postnum);
+                }
+            }
+
+        }
+    }
+}

--- a/test-suite/src/test/resources/jetty-logging.properties
+++ b/test-suite/src/test/resources/jetty-logging.properties
@@ -1,0 +1,2 @@
+org.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.StrErrLog
+org.eclipse.jetty.LEVEL=INFO

--- a/test-suite/src/test/resources/logback.xml
+++ b/test-suite/src/test/resources/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/test-suite/src/test/resources/marker-race-condition/application-context-h2.xml
+++ b/test-suite/src/test/resources/marker-race-condition/application-context-h2.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation=
+         "http://www.springframework.org/schema/beans
+            http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+     <!-- Hibernate -->
+    <bean name="feed-repository-bean"
+           class="org.atomhopper.hibernate.HibernateFeedRepository">
+        <constructor-arg>
+            <map>
+                 <!-- Start H2 Config -->
+              <entry key="hibernate.connection.url"
+                     value="jdbc:h2:/tmp/atomhopper/atom-hopper-db" />
+              <entry key="hibernate.connection.driver_class"
+                        value="org.h2.Driver" />
+                <entry key="hibernate.dialect"
+                        value="org.hibernate.dialect.H2Dialect" />
+                <entry key="hibernate.connection.username" value="sa" />
+                <entry key="hibernate.connection.password" value="" />
+                 <!-- End H2 Config -->
+
+                <entry key="hibernate.hbm2ddl.auto" value="update" />
+            </map>
+        </constructor-arg>
+    </bean>
+
+    <bean name="hibernate-feed-source"
+           class="org.atomhopper.hibernate.adapter.HibernateFeedSource">
+        <property name="feedRepository" ref="feed-repository-bean" />
+    </bean>
+
+    <bean name="hibernate-feed-publisher"
+           class="org.atomhopper.hibernate.adapter.HibernateFeedPublisher">
+        <property name="feedRepository" ref="feed-repository-bean" />
+    </bean>
+
+</beans>

--- a/test-suite/src/test/resources/marker-race-condition/atom-server.cfg.xml
+++ b/test-suite/src/test/resources/marker-race-condition/atom-server.cfg.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<atom-hopper-config xmlns="http://atomhopper.org/atom/hopper-config/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://atomhopper.org/atom/hopper-config/v1.0 ./../../config/atom-hopper-config.xsd">
+    <defaults>
+        <author name="Atom Hopper" />
+    </defaults>
+
+    <host domain="localhost:8080" scheme="http" />
+
+    <workspace title="Testing Namespace" resource="/namespace/">
+        <categories-descriptor reference="workspace-categories-descriptor" />
+
+        <feed title="Testing Feed" resource="/feed">
+            <feed-source reference="hibernate-feed-source" />
+            <publisher reference="hibernate-feed-publisher" />
+        </feed>
+    </workspace>
+</atom-hopper-config>


### PR DESCRIPTION
This set of patches solves an issue where pagination using a marker would miss entries due to a race condition. The fixes are mostly for the Hibernate adapter, but the problem likely exists for other adapters as well. Whether other adapters have the same issue has not been tested, but the `MarkerRaceConditionTest` should be able to reproduce the error given a suitable `application-context.xml` and test environment.