### PR TITLE
Cf 2428 2430

### DIFF
--- a/adapters/hibernate/src/main/java/org/atomhopper/hibernate/HibernateFeedRepository.java
+++ b/adapters/hibernate/src/main/java/org/atomhopper/hibernate/HibernateFeedRepository.java
@@ -191,13 +191,13 @@ public class HibernateFeedRepository implements FeedRepository {
 
     @Override
     public Set<PersistedCategory> updateCategories(final Set<PersistedCategory> categories) {
-        /* Creating caretories can fail if there's another request in parallel
+        /* Creating categories can fail if there's another request in parallel
          * attempting to create the same categories, in another transaction.
          * If that other transaction completes first, then the check for
          * whether categories already exist will indicate that they don't, due
          * to transaction isolation. After the ComplexSessionAction returns,
          * performComplexAction will attempt to commit, which fails due to the
-         * categories already aving been inserted and committed in the other
+         * categories already having been inserted and committed in the other
          * transaction.
          * To handle this, we need to retry the whole transaction. This time
          * around, the criterion that failed the earlier transaction will be

--- a/adapters/jdbc/src/main/java/org/atomhopper/jdbc/query/SearchToSqlConverter.java
+++ b/adapters/jdbc/src/main/java/org/atomhopper/jdbc/query/SearchToSqlConverter.java
@@ -28,7 +28,7 @@ import java.util.Map;
  *
  * An example configuration might be:
  *
- * A map of { "tid" => "tenantid", "type" => "eventype" } with a mark of ":".
+ * A map of { "tid" => "tenantid", "type" => "eventtype" } with a mark of ":".
  *
  * This maps the following atom categories:
  *

--- a/adapters/jdbc/src/test/java/org/atomhopper/jdbc/adapter/JdbcFeedSourceTest.java
+++ b/adapters/jdbc/src/test/java/org/atomhopper/jdbc/adapter/JdbcFeedSourceTest.java
@@ -137,7 +137,7 @@ public class JdbcFeedSourceTest {
             when(getFeedRequest.getDirection()).thenReturn("forward");
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
-            when(jdbcTemplate.queryForInt(any(String.class), any(Object[].class))).thenReturn(1);
+            when(jdbcTemplate.queryForObject(eq(any(String.class)), any(Object[].class), Integer.class)).thenReturn(1);
             assertEquals("Should get a 200 response", HttpStatus.OK,
                          archiveSource.getFeed(getFeedRequest).getResponseStatus());
 
@@ -201,7 +201,7 @@ public class JdbcFeedSourceTest {
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
-            when(jdbcTemplate.queryForInt(any(String.class), any(Object[].class))).thenReturn(1);
+            when(jdbcTemplate.queryForObject(eq(any(String.class)), any(Object[].class), Integer.class)).thenReturn(1);
             assertEquals("Should get a 200 response", HttpStatus.OK,
                     jdbcFeedSource.getFeed(getFeedRequest).getResponseStatus());
         }
@@ -217,7 +217,7 @@ public class JdbcFeedSourceTest {
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
-            when(jdbcTemplate.queryForInt(any(String.class), any(Object[].class))).thenReturn(1);
+            when(jdbcTemplate.queryForObject(eq(any(String.class)), any(Object[].class), Integer.class)).thenReturn(1);
             
             AdapterResponse<Feed> response = jdbcFeedSource.getFeed(getFeedRequest);
             String feedId = response.getBody().getId().toString();
@@ -236,7 +236,7 @@ public class JdbcFeedSourceTest {
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
-            when(jdbcTemplate.queryForInt(any(String.class), any(Object[].class))).thenReturn(1);
+            when(jdbcTemplate.queryForObject(eq(any(String.class)), any(Object[].class), Integer.class)).thenReturn(1);
             assertEquals("Should get a 200 response", HttpStatus.OK,
                     jdbcFeedSource.getFeed(getFeedRequest).getResponseStatus());
         }
@@ -252,7 +252,7 @@ public class JdbcFeedSourceTest {
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
-            when(jdbcTemplate.queryForInt(any(String.class), any(Object[].class))).thenReturn(1);
+            when(jdbcTemplate.queryForObject(eq(any(String.class)), any(Object[].class), Integer.class)).thenReturn(1);
 
             IRI iri = jdbcFeedSource.getFeed(getFeedRequest).getBody().getLink(MOCK_LAST_MARKER).getHref();
 
@@ -271,7 +271,7 @@ public class JdbcFeedSourceTest {
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
-            when(jdbcTemplate.queryForInt(any(String.class), any(Object[].class))).thenReturn(1);
+            when(jdbcTemplate.queryForObject(eq(any(String.class)), any(Object[].class), Integer.class)).thenReturn(1);
 
             IRI iri = jdbcFeedSource.getFeed(getFeedRequest).getBody().getLink(MOCK_LAST_MARKER).getHref();
 
@@ -512,7 +512,7 @@ public class JdbcFeedSourceTest {
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
-            when(jdbcTemplate.queryForInt(any(String.class), any(Object[].class))).thenReturn(1);
+            when(jdbcTemplate.queryForObject(eq(any(String.class)), any(Object[].class), Integer.class)).thenReturn(1);
             when(getFeedRequest.getPageSize()).thenReturn("13");
             assertEquals("Should get a 200 response", HttpStatus.OK,
                     jdbcFeedSource.getFeed(getFeedRequest).getResponseStatus());
@@ -532,7 +532,7 @@ public class JdbcFeedSourceTest {
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
-            when(jdbcTemplate.queryForInt(any(String.class), any(Object[].class))).thenReturn(1);
+            when(jdbcTemplate.queryForObject(eq(any(String.class)), any(Object[].class), Integer.class)).thenReturn(1);
             when(getFeedRequest.getPageSize()).thenReturn("13");
             assertEquals("Should get a 200 response", HttpStatus.OK,
                     jdbcFeedSource.getFeed(getFeedRequest).getResponseStatus());

--- a/adapters/jdbc/src/test/java/org/atomhopper/jdbc/adapter/JdbcFeedSourceTest.java
+++ b/adapters/jdbc/src/test/java/org/atomhopper/jdbc/adapter/JdbcFeedSourceTest.java
@@ -129,15 +129,10 @@ public class JdbcFeedSourceTest {
             archiveSource.setCurrentUrl( new URL( currentURL ) );
 
             Abdera localAbdera = new Abdera();
-            when(jdbcTemplate.queryForObject(any(String.class),
-                                             any(EntryRowMapper.class),
-                                             any(String.class),
-                                             any(String.class))).thenReturn(persistedEntry);
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getFeedRequest.getDirection()).thenReturn("forward");
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
-            when(jdbcTemplate.queryForObject(eq(any(String.class)), any(Object[].class), Integer.class)).thenReturn(1);
             assertEquals("Should get a 200 response", HttpStatus.OK,
                          archiveSource.getFeed(getFeedRequest).getResponseStatus());
 
@@ -168,10 +163,6 @@ public class JdbcFeedSourceTest {
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getFeedRequest.getPageMarker()).thenReturn(MARKER_ID);
             when(getFeedRequest.getDirection()).thenReturn("FORWARD");
-            when(jdbcTemplate.queryForObject(any(String.class),
-                                             any(EntryRowMapper.class),
-                                             any(String.class),
-                                             any(String.class))).thenReturn(null);
             assertEquals("Should get a 404 response", HttpStatus.NOT_FOUND,
                     jdbcFeedSource.getFeed(getFeedRequest).getResponseStatus());
         }
@@ -182,10 +173,6 @@ public class JdbcFeedSourceTest {
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getFeedRequest.getPageMarker()).thenReturn(MARKER_ID);
             when(getFeedRequest.getDirection()).thenReturn("BACKWARD");
-            when(jdbcTemplate.queryForObject(any(String.class),
-                                             any(EntryRowMapper.class),
-                                             any(String.class),
-                                             any(String.class))).thenReturn(null);
             assertEquals("Should get a 404 response", HttpStatus.NOT_FOUND,
                     jdbcFeedSource.getFeed(getFeedRequest).getResponseStatus());
         }
@@ -193,15 +180,10 @@ public class JdbcFeedSourceTest {
         @Test
         public void shouldGetFeedHead() throws Exception {
             Abdera localAbdera = new Abdera();
-            when(jdbcTemplate.queryForObject(any(String.class),
-                                             any(EntryRowMapper.class),
-                                             any(String.class),
-                                             any(String.class))).thenReturn(persistedEntry);
             when(getFeedRequest.getDirection()).thenReturn("forward");
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
-            when(jdbcTemplate.queryForObject(eq(any(String.class)), any(Object[].class), Integer.class)).thenReturn(1);
             assertEquals("Should get a 200 response", HttpStatus.OK,
                     jdbcFeedSource.getFeed(getFeedRequest).getResponseStatus());
         }
@@ -209,15 +191,10 @@ public class JdbcFeedSourceTest {
         @Test
         public void shouldGetFeedHeadWithIdInCorrectFormat() throws Exception {
             Abdera localAbdera = new Abdera();
-            when(jdbcTemplate.queryForObject(any(String.class),
-                    any(EntryRowMapper.class),
-                    any(String.class),
-                    any(String.class))).thenReturn(persistedEntry);
             when(getFeedRequest.getDirection()).thenReturn("forward");
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
-            when(jdbcTemplate.queryForObject(eq(any(String.class)), any(Object[].class), Integer.class)).thenReturn(1);
             
             AdapterResponse<Feed> response = jdbcFeedSource.getFeed(getFeedRequest);
             String feedId = response.getBody().getId().toString();
@@ -228,15 +205,10 @@ public class JdbcFeedSourceTest {
         public void shouldGetFeedHeadWithCategory() throws Exception {
             Abdera localAbdera = new Abdera();
             when(getFeedRequest.getSearchQuery()).thenReturn(SINGLE_CAT);
-            when(jdbcTemplate.queryForObject(any(String.class),
-                                             any(EntryRowMapper.class),
-                                             any(String.class),
-                                             any(String.class))).thenReturn(persistedEntry);
             when(getFeedRequest.getDirection()).thenReturn("forward");
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
-            when(jdbcTemplate.queryForObject(eq(any(String.class)), any(Object[].class), Integer.class)).thenReturn(1);
             assertEquals("Should get a 200 response", HttpStatus.OK,
                     jdbcFeedSource.getFeed(getFeedRequest).getResponseStatus());
         }
@@ -244,15 +216,10 @@ public class JdbcFeedSourceTest {
         @Test
         public void shouldGetFeedHeadWithLastLinkMarker() throws Exception {
             Abdera localAbdera = new Abdera();
-            when(jdbcTemplate.queryForObject(any(String.class),
-                    any(EntryRowMapper.class),
-                    any(String.class),
-                    any(String.class))).thenReturn(persistedEntry);
             when(getFeedRequest.getDirection()).thenReturn("forward");
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
-            when(jdbcTemplate.queryForObject(eq(any(String.class)), any(Object[].class), Integer.class)).thenReturn(1);
 
             IRI iri = jdbcFeedSource.getFeed(getFeedRequest).getBody().getLink(MOCK_LAST_MARKER).getHref();
 
@@ -263,15 +230,10 @@ public class JdbcFeedSourceTest {
         public void shouldGetFeedHeadWithLastLinkMarkerAndCategory() throws Exception {
             Abdera localAbdera = new Abdera();
             when(getFeedRequest.getSearchQuery()).thenReturn(SINGLE_CAT);
-            when(jdbcTemplate.queryForObject(any(String.class),
-                    any(EntryRowMapper.class),
-                    any(String.class),
-                    any(String.class))).thenReturn(persistedEntry);
             when(getFeedRequest.getDirection()).thenReturn("forward");
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
-            when(jdbcTemplate.queryForObject(eq(any(String.class)), any(Object[].class), Integer.class)).thenReturn(1);
 
             IRI iri = jdbcFeedSource.getFeed(getFeedRequest).getBody().getLink(MOCK_LAST_MARKER).getHref();
 
@@ -282,10 +244,6 @@ public class JdbcFeedSourceTest {
         public void shouldGetFeedWithLastMarkerAndContainNextArchive() throws Exception {
             Abdera localAbdera = new Abdera();
             when(getFeedRequest.getPageMarker()).thenReturn(MOCK_LAST_MARKER);
-            when(jdbcTemplate.queryForObject(any(String.class),
-                    any(EntryRowMapper.class),
-                    any(String.class),
-                    any(String.class))).thenReturn(persistedEntry);
             when(jdbcTemplate.query(any(String.class),
                                     any( Object[].class ),
                                     any(EntryRowMapper.class))).thenReturn( new ArrayList<PersistedEntry>() );
@@ -305,10 +263,6 @@ public class JdbcFeedSourceTest {
             when(getFeedRequest.getPageMarker()).thenReturn(MOCK_LAST_MARKER);
             when(getFeedRequest.getSearchQuery()).thenReturn(SINGLE_CAT);
             when(getFeedRequest.getDirection()).thenReturn("forward");
-            when(jdbcTemplate.queryForObject(any(String.class),
-                    any(EntryRowMapper.class),
-                    any(String.class),
-                    any(String.class))).thenReturn(persistedEntry);
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
@@ -321,10 +275,6 @@ public class JdbcFeedSourceTest {
             when(getFeedRequest.getPageMarker()).thenReturn(MARKER_ID);
             when(getFeedRequest.getDirection()).thenReturn(FORWARD);
             Abdera localAbdera = new Abdera();
-            when(jdbcTemplate.queryForObject(any(String.class),
-                                             any(EntryRowMapper.class),
-                                             any(String.class),
-                                             any(String.class))).thenReturn(persistedEntry);
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
@@ -337,10 +287,6 @@ public class JdbcFeedSourceTest {
             when(getFeedRequest.getPageMarker()).thenReturn(MARKER_ID);
             when(getFeedRequest.getDirection()).thenReturn(BACKWARD);
             Abdera localAbdera = new Abdera();
-            when(jdbcTemplate.queryForObject(any(String.class),
-                                             any(EntryRowMapper.class),
-                                             any(String.class),
-                                             any(String.class))).thenReturn(persistedEntry);
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
@@ -354,10 +300,6 @@ public class JdbcFeedSourceTest {
             when(getFeedRequest.getDirection()).thenReturn(FORWARD);
             when(getFeedRequest.getSearchQuery()).thenReturn(SINGLE_CAT);
             Abdera localAbdera = new Abdera();
-            when(jdbcTemplate.queryForObject(any(String.class),
-                                             any(EntryRowMapper.class),
-                                             any(String.class),
-                                             any(String.class))).thenReturn(persistedEntry);
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
@@ -371,10 +313,6 @@ public class JdbcFeedSourceTest {
             when(getFeedRequest.getDirection()).thenReturn(BACKWARD);
             when(getFeedRequest.getSearchQuery()).thenReturn(SINGLE_CAT);
             Abdera localAbdera = new Abdera();
-            when(jdbcTemplate.queryForObject(any(String.class),
-                                             any(EntryRowMapper.class),
-                                             any(String.class),
-                                             any(String.class))).thenReturn(persistedEntry);
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
@@ -388,10 +326,6 @@ public class JdbcFeedSourceTest {
             when(getFeedRequest.getDirection()).thenReturn(FORWARD);
             when(getFeedRequest.getSearchQuery()).thenReturn(MULTI_CAT);
             Abdera localAbdera = new Abdera();
-            when(jdbcTemplate.queryForObject(any(String.class),
-                                             any(EntryRowMapper.class),
-                                             any(String.class),
-                                             any(String.class))).thenReturn(persistedEntry);
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
@@ -405,10 +339,6 @@ public class JdbcFeedSourceTest {
             when(getFeedRequest.getDirection()).thenReturn(BACKWARD);
             when(getFeedRequest.getSearchQuery()).thenReturn(MULTI_CAT);
             Abdera localAbdera = new Abdera();
-            when(jdbcTemplate.queryForObject(any(String.class),
-                                             any(EntryRowMapper.class),
-                                             any(String.class),
-                                             any(String.class))).thenReturn(persistedEntry);
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
@@ -422,10 +352,6 @@ public class JdbcFeedSourceTest {
             when(getFeedRequest.getDirection()).thenReturn(BACKWARD);
             when(getFeedRequest.getSearchQuery()).thenReturn(AND_CAT);
             Abdera localAbdera = new Abdera();
-            when(jdbcTemplate.queryForObject(any(String.class),
-                                             any(EntryRowMapper.class),
-                                             any(String.class),
-                                             any(String.class))).thenReturn(persistedEntry);
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
@@ -439,10 +365,6 @@ public class JdbcFeedSourceTest {
             when(getFeedRequest.getDirection()).thenReturn(BACKWARD);
             when(getFeedRequest.getSearchQuery()).thenReturn(OR_CAT);
             Abdera localAbdera = new Abdera();
-            when(jdbcTemplate.queryForObject(any(String.class),
-                                             any(EntryRowMapper.class),
-                                             any(String.class),
-                                             any(String.class))).thenReturn(persistedEntry);
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
@@ -456,10 +378,6 @@ public class JdbcFeedSourceTest {
             when(getFeedRequest.getDirection()).thenReturn(BACKWARD);
             when(getFeedRequest.getSearchQuery()).thenReturn(NOT_CAT);
             Abdera localAbdera = new Abdera();
-            when(jdbcTemplate.queryForObject(any(String.class),
-                                             any(EntryRowMapper.class),
-                                             any(String.class),
-                                             any(String.class))).thenReturn(persistedEntry);
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
@@ -504,15 +422,10 @@ public class JdbcFeedSourceTest {
             jdbcFeedSource.setEnableLoggingOnShortPage(Boolean.TRUE);
             JdbcFeedSource.LOG = mock(Logger.class);
             Abdera localAbdera = new Abdera();
-            when(jdbcTemplate.queryForObject(any(String.class),
-                    any(EntryRowMapper.class),
-                    any(String.class),
-                    any(String.class))).thenReturn(persistedEntry);
             when(getFeedRequest.getDirection()).thenReturn("forward");
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
-            when(jdbcTemplate.queryForObject(eq(any(String.class)), any(Object[].class), Integer.class)).thenReturn(1);
             when(getFeedRequest.getPageSize()).thenReturn("13");
             assertEquals("Should get a 200 response", HttpStatus.OK,
                     jdbcFeedSource.getFeed(getFeedRequest).getResponseStatus());
@@ -524,15 +437,10 @@ public class JdbcFeedSourceTest {
             jdbcFeedSource.setEnableLoggingOnShortPage(Boolean.FALSE);
             JdbcFeedSource.LOG = mock(Logger.class);
             Abdera localAbdera = new Abdera();
-            when(jdbcTemplate.queryForObject(any(String.class),
-                    any(EntryRowMapper.class),
-                    any(String.class),
-                    any(String.class))).thenReturn(persistedEntry);
             when(getFeedRequest.getDirection()).thenReturn("forward");
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
-            when(jdbcTemplate.queryForObject(eq(any(String.class)), any(Object[].class), Integer.class)).thenReturn(1);
             when(getFeedRequest.getPageSize()).thenReturn("13");
             assertEquals("Should get a 200 response", HttpStatus.OK,
                     jdbcFeedSource.getFeed(getFeedRequest).getResponseStatus());
@@ -546,10 +454,6 @@ public class JdbcFeedSourceTest {
             when(getFeedRequest.getPageMarker()).thenReturn("2014-03-06T06:00:00Z");
             when(getFeedRequest.getDirection()).thenReturn("FORWARD");
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
-            when(jdbcTemplate.queryForObject(any(String.class),
-                    any(EntryRowMapper.class),
-                    any(String.class),
-                    any(String.class))).thenReturn(entryList);
             assertEquals("Should get a 200 response", HttpStatus.OK,
                     jdbcFeedSource.getFeed(getFeedRequest).getResponseStatus());
         }
@@ -562,10 +466,6 @@ public class JdbcFeedSourceTest {
             when(getFeedRequest.getStartingAt()).thenReturn("20140306T060000");
             when(getFeedRequest.getDirection()).thenReturn("FORWARD");
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
-            when(jdbcTemplate.queryForObject(any(String.class),
-                    any(EntryRowMapper.class),
-                    any(String.class),
-                    any(String.class))).thenReturn(entryList);
             assertEquals("Should get a 400 response", HttpStatus.BAD_REQUEST,
                     jdbcFeedSource.getFeed(getFeedRequest).getResponseStatus());
         }
@@ -578,10 +478,6 @@ public class JdbcFeedSourceTest {
             when(getFeedRequest.getStartingAt()).thenReturn("20140306T060000");
             when(getFeedRequest.getDirection()).thenReturn("FORWARD");
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
-            when(jdbcTemplate.queryForObject(any(String.class),
-                    any(EntryRowMapper.class),
-                    any(String.class),
-                    any(String.class))).thenReturn(entryList);
             assertEquals("Should get a 400 response", HttpStatus.BAD_REQUEST,
                     jdbcFeedSource.getFeed(getFeedRequest).getResponseStatus());
         }

--- a/adapters/postgres-adapter/src/test/java/org/atomhopper/postgres/adapter/PostgresFeedSourceTest.java
+++ b/adapters/postgres-adapter/src/test/java/org/atomhopper/postgres/adapter/PostgresFeedSourceTest.java
@@ -132,7 +132,7 @@ public class PostgresFeedSourceTest {
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
-            when(jdbcTemplate.queryForInt(any(String.class), any(Object[].class))).thenReturn(1);
+            when(jdbcTemplate.queryForObject(eq(any(String.class)), any(Object[].class), Integer.class)).thenReturn(1);
             assertEquals("Should get a 200 response", HttpStatus.OK,
                          postgresFeedSource.getFeed(getFeedRequest).getResponseStatus());
         }
@@ -148,7 +148,7 @@ public class PostgresFeedSourceTest {
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
-            when(jdbcTemplate.queryForInt(any(String.class), any(Object[].class))).thenReturn(1);
+            when(jdbcTemplate.queryForObject(eq(any(String.class)), any(Object[].class), Integer.class)).thenReturn(1);
             assertEquals("Should get a 200 response", HttpStatus.OK,
                          postgresFeedSource.getFeed(getFeedRequest).getResponseStatus());
         }
@@ -343,7 +343,8 @@ public class PostgresFeedSourceTest {
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
-            when(jdbcTemplate.queryForInt(any(String.class), any(Object[].class))).thenReturn(1);
+            when(jdbcTemplate.queryForObject(eq(any(String.class)), any(Object[].class), Integer.class)).thenReturn(1);
+//            when(jdbcTemplate.queryForInt(any(String.class), any(Object[].class))).thenReturn(1);
             assertEquals("Should get a 200 response", HttpStatus.OK,
                          archiveSource.getFeed(getFeedRequest).getResponseStatus());
 

--- a/adapters/postgres-adapter/src/test/java/org/atomhopper/postgres/adapter/PostgresFeedSourceTest.java
+++ b/adapters/postgres-adapter/src/test/java/org/atomhopper/postgres/adapter/PostgresFeedSourceTest.java
@@ -100,10 +100,6 @@ public class PostgresFeedSourceTest {
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getFeedRequest.getPageMarker()).thenReturn(MARKER_ID);
             when(getFeedRequest.getDirection()).thenReturn("FORWARD");
-            when(jdbcTemplate.queryForObject(any(String.class),
-                                             any(EntryRowMapper.class),
-                                             any(String.class),
-                                             any(String.class))).thenReturn(null);
             assertEquals("Should get a 404 response", HttpStatus.NOT_FOUND,
                          postgresFeedSource.getFeed(getFeedRequest).getResponseStatus());
         }
@@ -114,10 +110,6 @@ public class PostgresFeedSourceTest {
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getFeedRequest.getPageMarker()).thenReturn(MARKER_ID);
             when(getFeedRequest.getDirection()).thenReturn("BACKWARD");
-            when(jdbcTemplate.queryForObject(any(String.class),
-                                             any(EntryRowMapper.class),
-                                             any(String.class),
-                                             any(String.class))).thenReturn(null);
             assertEquals("Should get a 404 response", HttpStatus.NOT_FOUND,
                          postgresFeedSource.getFeed(getFeedRequest).getResponseStatus());
         }
@@ -125,14 +117,9 @@ public class PostgresFeedSourceTest {
         @Test
         public void shouldGetFeedHead() throws Exception {
             Abdera localAbdera = new Abdera();
-            when(jdbcTemplate.queryForObject(any(String.class),
-                                             any(EntryRowMapper.class),
-                                             any(String.class),
-                                             any(String.class))).thenReturn(persistedEntry);
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
-            when(jdbcTemplate.queryForObject(eq(any(String.class)), any(Object[].class), Integer.class)).thenReturn(1);
             assertEquals("Should get a 200 response", HttpStatus.OK,
                          postgresFeedSource.getFeed(getFeedRequest).getResponseStatus());
         }
@@ -141,14 +128,9 @@ public class PostgresFeedSourceTest {
         public void shouldGetFeedHeadWithCategory() throws Exception {
             Abdera localAbdera = new Abdera();
             when(getFeedRequest.getSearchQuery()).thenReturn(SINGLE_CAT);
-            when(jdbcTemplate.queryForObject(any(String.class),
-                                             any(EntryRowMapper.class),
-                                             any(String.class),
-                                             any(String.class))).thenReturn(persistedEntry);
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
-            when(jdbcTemplate.queryForObject(eq(any(String.class)), any(Object[].class), Integer.class)).thenReturn(1);
             assertEquals("Should get a 200 response", HttpStatus.OK,
                          postgresFeedSource.getFeed(getFeedRequest).getResponseStatus());
         }
@@ -158,10 +140,6 @@ public class PostgresFeedSourceTest {
             when(getFeedRequest.getPageMarker()).thenReturn(MARKER_ID);
             when(getFeedRequest.getDirection()).thenReturn(FORWARD);
             Abdera localAbdera = new Abdera();
-            when(jdbcTemplate.queryForObject(any(String.class),
-                                             any(EntryRowMapper.class),
-                                             any(String.class),
-                                             any(String.class))).thenReturn(persistedEntry);
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
@@ -174,10 +152,6 @@ public class PostgresFeedSourceTest {
             when(getFeedRequest.getPageMarker()).thenReturn(MARKER_ID);
             when(getFeedRequest.getDirection()).thenReturn(BACKWARD);
             Abdera localAbdera = new Abdera();
-            when(jdbcTemplate.queryForObject(any(String.class),
-                                             any(EntryRowMapper.class),
-                                             any(String.class),
-                                             any(String.class))).thenReturn(persistedEntry);
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
@@ -191,10 +165,6 @@ public class PostgresFeedSourceTest {
             when(getFeedRequest.getDirection()).thenReturn(FORWARD);
             when(getFeedRequest.getSearchQuery()).thenReturn(SINGLE_CAT);
             Abdera localAbdera = new Abdera();
-            when(jdbcTemplate.queryForObject(any(String.class),
-                                             any(EntryRowMapper.class),
-                                             any(String.class),
-                                             any(String.class))).thenReturn(persistedEntry);
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
@@ -208,10 +178,6 @@ public class PostgresFeedSourceTest {
             when(getFeedRequest.getDirection()).thenReturn(BACKWARD);
             when(getFeedRequest.getSearchQuery()).thenReturn(SINGLE_CAT);
             Abdera localAbdera = new Abdera();
-            when(jdbcTemplate.queryForObject(any(String.class),
-                                             any(EntryRowMapper.class),
-                                             any(String.class),
-                                             any(String.class))).thenReturn(persistedEntry);
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
@@ -225,10 +191,6 @@ public class PostgresFeedSourceTest {
             when(getFeedRequest.getDirection()).thenReturn(FORWARD);
             when(getFeedRequest.getSearchQuery()).thenReturn(MULTI_CAT);
             Abdera localAbdera = new Abdera();
-            when(jdbcTemplate.queryForObject(any(String.class),
-                                             any(EntryRowMapper.class),
-                                             any(String.class),
-                                             any(String.class))).thenReturn(persistedEntry);
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
@@ -242,10 +204,6 @@ public class PostgresFeedSourceTest {
             when(getFeedRequest.getDirection()).thenReturn(BACKWARD);
             when(getFeedRequest.getSearchQuery()).thenReturn(MULTI_CAT);
             Abdera localAbdera = new Abdera();
-            when(jdbcTemplate.queryForObject(any(String.class),
-                                             any(EntryRowMapper.class),
-                                             any(String.class),
-                                             any(String.class))).thenReturn(persistedEntry);
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
@@ -309,10 +267,6 @@ public class PostgresFeedSourceTest {
             when( getFeedRequest.getDirection() ).thenReturn( BACKWARD );
             when( getFeedRequest.getFeedName() ).thenReturn( FEED_NAME );
             when( getFeedRequest.getAbdera() ).thenReturn( localAbdera );
-            when(jdbcTemplate.queryForObject( any( String.class ),
-                                              any( EntryRowMapper.class ),
-                                              any( String.class ),
-                                              any( String.class ) ) ).thenReturn( persistedEntry );
             when( jdbcTemplate.query( any( String.class ),
                                       any( Object[].class ),
                                       any( EntryRowMapper.class ) ) ).thenReturn( entryList );
@@ -336,14 +290,9 @@ public class PostgresFeedSourceTest {
             archiveSource.setCurrentUrl( new URL( currentURL ) );
 
             Abdera localAbdera = new Abdera();
-            when(jdbcTemplate.queryForObject(any(String.class),
-                                             any(EntryRowMapper.class),
-                                             any(String.class),
-                                             any(String.class))).thenReturn(persistedEntry);
             when(getFeedRequest.getAbdera()).thenReturn(localAbdera);
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
-            when(jdbcTemplate.queryForObject(eq(any(String.class)), any(Object[].class), Integer.class)).thenReturn(1);
             assertEquals("Should get a 200 response", HttpStatus.OK,
                          archiveSource.getFeed(getFeedRequest).getResponseStatus());
 

--- a/adapters/postgres-adapter/src/test/java/org/atomhopper/postgres/adapter/PostgresFeedSourceTest.java
+++ b/adapters/postgres-adapter/src/test/java/org/atomhopper/postgres/adapter/PostgresFeedSourceTest.java
@@ -344,7 +344,6 @@ public class PostgresFeedSourceTest {
             when(getEntryRequest.getAbdera()).thenReturn(localAbdera);
             when(jdbcTemplate.query(any(String.class), any(Object[].class), any(EntryRowMapper.class))).thenReturn(entryList);
             when(jdbcTemplate.queryForObject(eq(any(String.class)), any(Object[].class), Integer.class)).thenReturn(1);
-//            when(jdbcTemplate.queryForInt(any(String.class), any(Object[].class))).thenReturn(1);
             assertEquals("Should get a 200 response", HttpStatus.OK,
                          archiveSource.getFeed(getFeedRequest).getResponseStatus());
 

--- a/atomhopper/pom.xml
+++ b/atomhopper/pom.xml
@@ -401,12 +401,12 @@
                 <dependency>
                     <groupId>org.apache.httpcomponents</groupId>
                     <artifactId>httpclient</artifactId>
-                    <version>4.3.6</version>
+                    <version>4.5.7</version>
                 </dependency>
                 <dependency>
                     <groupId>org.apache.httpcomponents</groupId>
                     <artifactId>httpcore</artifactId>
-                    <version>4.3</version>
+                    <version>4.4.11</version>
                 </dependency>
             </dependencies>
             <build>

--- a/atomhopper/pom.xml
+++ b/atomhopper/pom.xml
@@ -401,7 +401,7 @@
                 <dependency>
                     <groupId>org.apache.httpcomponents</groupId>
                     <artifactId>httpclient</artifactId>
-                    <version>4.3.3</version>
+                    <version>4.3.6</version>
                 </dependency>
                 <dependency>
                     <groupId>org.apache.httpcomponents</groupId>
@@ -468,11 +468,11 @@
                                         // Step 2 - upload the file to scan
                                         // Note: I could not make the MultipartEntity to work with
                                         // HttpBuilder class. So I resorted to calling curl
-                                        println "Uploading file ${project.basedir}/target/atomhopper-${version}.war to /api/4.0/uploadfile.do"
+                                        println "Uploading file ${project.basedir}/target/atomhopper-${project.version}.war to /api/4.0/uploadfile.do"
                                         def uploadCurl = ["curl", "--compressed",
                                                           "-u", "${veracode.username}:${veracode.password}",
                                                           "-F", "app_id=${appId}",
-                                                          "-F", "file=@${project.basedir}/target/atomhopper-${version}.war",
+                                                          "-F", "file=@${project.basedir}/target/atomhopper-${project.version}.war",
                                                           "-F", "save_as=atomhopper.war",
                                                           "${veracodeUrl}4.0/uploadfile.do"]
                                         def proc = uploadCurl.execute()

--- a/pom.xml
+++ b/pom.xml
@@ -347,7 +347,7 @@
             <dependency>
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>
-                <version>2.3</version>
+                <version>2.10.1</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -13,11 +13,12 @@
     <properties>
         <project.license>apache20</project.license>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <org.springframework.version>3.1.1.RELEASE</org.springframework.version>
+        <org.springframework.version>4.3.22.RELEASE</org.springframework.version>
         <org.springframework.data.version>1.0.0.RELEASE</org.springframework.data.version>
         <org.aspectj.version>1.6.9</org.aspectj.version>
         <cglib.version>2.2</cglib.version>
         <metrics.version>3.0.1</metrics.version>
+        <jetty.version>9.4.14.v20181114</jetty.version>
     </properties>
 
     <licenses>
@@ -233,13 +234,13 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-server</artifactId>
-                <version>8.1.0.v20120127</version>
+                <version>${jetty.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-servlet</artifactId>
-                <version>8.1.0.v20120127</version>
+                <version>${jetty.version}</version>
             </dependency>
 
             <dependency>

--- a/server/src/main/java/org/atomhopper/server/AtomHopperServerControl.java
+++ b/server/src/main/java/org/atomhopper/server/AtomHopperServerControl.java
@@ -50,7 +50,7 @@ public class AtomHopperServerControl {
             out.flush();
             s.close();
         } catch (IOException ioex) {
-            LOG.error("An error occured while attempting to stop Atom Hopper: " + ioex.getMessage());
+            LOG.error("An error occurred while attempting to stop Atom Hopper: " + ioex.getMessage());
         }
     }
 


### PR DESCRIPTION
## Change Overview

Several vulernabilities were identified within existing dependencies of Atom Hopper which have been patched in newer versions. Along with the version changes, an upgrade from Spring 3 to Spring 4 is being pushed.

The following dependencies are being being updated for this reason:
[jetty](https://github.com/rackerlabs/atom-hopper/blob/4e3a929e1ab4babb7b7089b832009e1235e53cae/pom.xml#L233-L243)
[http-commons-client](https://github.com/rackerlabs/atom-hopper/blob/4e3a929e1ab4babb7b7089b832009e1235e53cae/atomhopper/pom.xml#L401-L410)
[springframework](https://github.com/rackerlabs/atom-hopper/blob/4e3a929e1ab4babb7b7089b832009e1235e53cae/pom.xml#L16)

In addition, Joda Time is being kept up to date until a Java migration at a later date.

Also, I found some typos in comments/logging while onboarding that I didn't have the opportunity to address until now.

## Code Changes

**Dependency Updates**

Dependency updates took place in the `pom.xml` and `atomhopper/pom.xml` files.

**Test Updates**

The Spring Framework migration from 3 to 4 depcrecated the `queryForInt` method. To address, the `queryForObject` method has been employed while passing `Integer.class` to replicate functionality. This also requires using an explicit matcher using `eq` for the first parameter. These changes can be found in the following locations:

```
cd adapter/src/test/java/org/atomhopper/postgres/adapter
view PostgresFeedSourceTest.java
cd adapters/jdbc/src/test/java/org/atomhopper/jdbc/adapter
view JdbcFeedSourceTest.java
```

**Misc Updates**

There are a number of minor string updates to correct typos. These are negligible in impact but should be evaluated for correctness in the following locations:

[HibernateFeedRepository](https://github.com/rackerlabs/atom-hopper/pull/300/files#diff-a54afda7fda68ff680daec78f0d9d8df)

Comment: `caretories` -> `categories`
Comment: `aving` -> `having`

[SearchToSqlConverter](https://github.com/rackerlabs/atom-hopper/pull/300/files#diff-9b7eaf1be0325af56412dcb78f658a5d)

Comment: `eventype` -> `eventtype`

[AtomHopperServerControl](https://github.com/rackerlabs/atom-hopper/pull/300/files#diff-2d2b0d2a1aaa7ad0322b9e9676e52d12)

Logging: `occured` -> `occurred`

## Validate Updates

I validated state dependencies with `mvn install` as runtime dependencies will require a release to check. RIP.

## Additional Info

**Stories:**
https://jira.rax.io/browse/CF-2428
https://jira.rax.io/browse/CF-2429
https://jira.rax.io/browse/CF-2430
