### PR TITLE
updated mysql-connector, xerces,jettyserver version to remove secrity vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <org.aspectj.version>1.6.9</org.aspectj.version>
         <cglib.version>2.2</cglib.version>
         <metrics.version>3.0.1</metrics.version>
-        <jetty.version>9.4.14.v20181114</jetty.version>
+        <jetty.version>9.4.17.v20190418</jetty.version>
     </properties>
 
     <licenses>
@@ -119,7 +119,7 @@
             <dependency>
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
-                <version>5.1.20</version>
+                <version>8.0.16</version>
             </dependency>
 
             <dependency>
@@ -353,7 +353,7 @@
             <dependency>
                 <groupId>xerces</groupId>
                 <artifactId>xercesImpl</artifactId>
-                <version>2.11.0</version>
+                <version>2.12.0</version>
             </dependency>
             <dependency>
                 <groupId>xml-apis</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,7 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.8.2</version>
+                <version>4.13.1</version>
                 <scope>test</scope>
             </dependency>
 

--- a/tests/jetty-killer/pom.xml
+++ b/tests/jetty-killer/pom.xml
@@ -188,7 +188,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.8.2</version>
+      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
Updated to these version for security problems in pom.xml file.
1. **Mysql connector** 
<dependency>
  <groupId>mysql</groupId>
  <artifactId>mysql-connector-java</artifactId>
  <version>[8.0.16,)</version>
</dependency>

2. **xercesImpl**
<dependency>
  <groupId>xerces</groupId>
  <artifactId>xercesImpl</artifactId>
  <version>[2.12.0,)</version>
</dependency>

3.**org.eclipse.jetty:jetty-server**
<dependency>
  <groupId>org.eclipse.jetty</groupId>
  <artifactId>jetty-server</artifactId>
  <version>[9.4.17.v20190418,)</version>
</dependency>
