### PR TITLE
Tenant-Id-Issue

### DIFF
--- a/adapters/dynamoDB_adapters/src/main/java/org/atomhopper/dynamodb/adapter/DynamoDBFeedSource.java
+++ b/adapters/dynamoDB_adapters/src/main/java/org/atomhopper/dynamodb/adapter/DynamoDBFeedSource.java
@@ -288,7 +288,7 @@ public class DynamoDBFeedSource implements FeedSource {
         ValueMap valueMap = new ValueMap();
         valueMap.withString(":feed", feed);
         valueMap.withString(":dateLastUpdated", String.valueOf(markerDate));
-        return getQueryBuilderMethod(dynamoDB, "feed = :feed" , getTimeStampValueFilter(direction), valueMap);
+        return getQueryBuilderMethod(dynamoDB, "feed = :feed and " + getTimeStampValueFilter(direction) , null, valueMap);
     }
 
     /**
@@ -514,23 +514,13 @@ public class DynamoDBFeedSource implements FeedSource {
         List<String> categoriesList = getSearchToSqlConverter().getParamsFromSearchString(searchString);
         int numCats = categoriesList.size();
 
-        Object[] parms = null;
+        String filterExpression = null;
 
         if (numCats > 0) {
-            parms = new Object[numCats + 2];
-            int index = 0;
-            parms[index++] = feedName;
-            for (String s : categoriesList) {
-                parms[index++] = s;
-            }
-            parms[index++] = pageSize;
-
-        } else {
-            parms = new Object[]{feedName, pageSize};
+            filterExpression = "(contains(categories, :categories))";
         }
 
         TimerContext context = null;
-        List<PersistedEntry> lastPersistedEntries;
         try {
             if (numCats > 0) {
                 context = startTimer(
@@ -542,7 +532,7 @@ public class DynamoDBFeedSource implements FeedSource {
             List<String> feedPage;
             ValueMap valueMap = new ValueMap();
             valueMap.withString(":feed", feedName);
-            feedPage = getQueryBuilderMethod(dynamoDB, "feed = :feed" ,"dateLastUpdated < :dateLastUpdated", pageSize, valueMap, true);
+            feedPage = getQueryBuilderMethod(dynamoDB, "feed = :feed and dateLastUpdated < :dateLastUpdated" ,filterExpression, pageSize, valueMap, true);
             // comparator is written to perform sorting based on if two dates are equal then sort output based on entryId in desc order
             List<PersistedEntry> persistedEntryList = JsonUtil.getPersistenceEntity(feedPage);
             Collections.sort(persistedEntryList, (a, b) -> {
@@ -619,18 +609,11 @@ public class DynamoDBFeedSource implements FeedSource {
         List<String> categoriesList = getSearchToSqlConverter().getParamsFromSearchString(searchString);
         int numCats = categoriesList.size();
 
-        Object[] parms = null;
+        
+        String filterExpression = null;
 
         if (numCats > 0) {
-            parms = new Object[numCats + 2];
-            int index = 0;
-            parms[index++] = feedName;
-            for (String s : categoriesList) {
-                parms[index++] = s;
-            }
-            parms[index++] = pageSize;
-        } else {
-            parms = new Object[]{feedName, pageSize};
+            filterExpression = "(contains(categories, :categories))";
         }
 
         TimerContext context = null;
@@ -645,7 +628,10 @@ public class DynamoDBFeedSource implements FeedSource {
             List<String> feedPage;
             ValueMap valueMap = new ValueMap();
             valueMap.withString(":feed", feedName);
-            feedPage = getQueryBuilderMethod(dynamoDB, "feed = :feed",null, pageSize, valueMap, false);
+            for(String s: categoriesList){
+                valueMap.withString(":categories", s);
+            }
+            feedPage = getQueryBuilderMethod(dynamoDB, "feed = :feed",filterExpression, pageSize, valueMap, false);
             List<PersistedEntry> persistedEntryList = JsonUtil.getPersistenceEntity(feedPage);
             return persistedEntryList;
         } finally {
@@ -765,41 +751,25 @@ public class DynamoDBFeedSource implements FeedSource {
         List<String> categoriesList = getSearchToSqlConverter().getParamsFromSearchString(searchString);
         int numCats = categoriesList.size();
 
-        Object[] parms = null;
+        String filterExpression = null;
 
-        if (categoriesList.size() > 0) {
-            parms = new Object[numCats * 2 + 5];
-            int index = 0;
-            parms[index++] = feedName;
-            parms[index++] = persistedEntry.getDateLastUpdated();
-            parms[index++] = persistedEntry.getEntryId();
-            for (String s : categoriesList) {
-                parms[index++] = s;
-            }
-            parms[index++] = feedName;
-            parms[index++] = persistedEntry.getDateLastUpdated();
-            for (String s : categoriesList) {
-                parms[index++] = s;
-            }
-
-        } else {
-            parms = new Object[]{feedName, persistedEntry.getDateLastUpdated(), persistedEntry.getEntryId(),
-                    feedName, persistedEntry.getDateLastUpdated()};
+        if (numCats > 0) {
+            filterExpression = "(contains(categories, :categories))";
         }
 
-        List<String> feedPage;
+
+
         List<String> firstUnionPersistentList;
         ValueMap valueMap = new ValueMap();
         valueMap.withString(":feed", persistedEntry.getFeed());
-        firstUnionPersistentList = getQueryBuilderMethod(dynamoDB, "feed = :feed ",null, valueMap);
-        List<String> nextUnionListOfPersistedItems;
-        ValueMap newValueMap = new ValueMap();
-        newValueMap.withString(":feed", persistedEntry.getFeed());
-        
-        nextUnionListOfPersistedItems = getQueryBuilderMethod(dynamoDB, "feed = :feed",null, valueMap);
-        feedPage = Stream.concat(firstUnionPersistentList.stream(), nextUnionListOfPersistedItems.stream())
-                .collect(Collectors.toList());
-        List<PersistedEntry> persistedEntryList = JsonUtil.getPersistenceEntity(feedPage);
+
+        for(String s: categoriesList){
+
+            valueMap.withString(":categories", s);
+        }
+
+        firstUnionPersistentList = getQueryBuilderMethod(dynamoDB, "feed = :feed ",filterExpression, valueMap);
+        List<PersistedEntry> persistedEntryList = JsonUtil.getPersistenceEntity(firstUnionPersistentList);
         return persistedEntryList.get(0);
     }
 
@@ -934,7 +904,13 @@ public class DynamoDBFeedSource implements FeedSource {
             .withScanIndexForward(orderBy);
         }
         // for descending order sorting on lastDateUpdated
-        ItemCollection<QueryOutcome> persistedEntryItems = index.query(spec);
+        ItemCollection<QueryOutcome> persistedEntryItems = null;
+        try{
+            persistedEntryItems = index.query(spec);
+        }catch(Exception e){
+            LOG.error("Exception " + e + e.getMessage());
+        }
+        
         Iterator<Item> itemsIterator = persistedEntryItems.iterator();
         while (itemsIterator.hasNext()) {
             Item item = itemsIterator.next();
@@ -952,17 +928,15 @@ public class DynamoDBFeedSource implements FeedSource {
      * @return List of String in json format.
      */
     public List<String> getQueryBuilderMethod(DynamoDB dynamoDB, String conditionExpression,String filterExpression, ValueMap valueMap) {
-        LOG.error("getQueryBuilderMethod");
-        LOG.error("conditionExpression " + conditionExpression);
-        LOG.error("valueMap" + valueMap.toString());
+
         List<String> feedPage = new ArrayList<>();
         Table table = dynamoDB.getTable("entries");
         Index index = table.getIndex("global-feed-index");
         QuerySpec spec;
         if(null != filterExpression){
           spec  = new QuerySpec()
-            .withKeyConditionExpression(conditionExpression + " and " + filterExpression)
-            // .withFilterExpression(filterExpression)
+            .withKeyConditionExpression(conditionExpression)
+            .withFilterExpression(filterExpression)
             .withScanIndexForward(true)
             .withValueMap(valueMap);
         }else{

--- a/adapters/dynamoDB_adapters/src/main/java/org/atomhopper/dynamodb/adapter/DynamoDBFeedSource.java
+++ b/adapters/dynamoDB_adapters/src/main/java/org/atomhopper/dynamodb/adapter/DynamoDBFeedSource.java
@@ -7,7 +7,6 @@ import com.amazonaws.services.dynamodbv2.document.*;
 import com.amazonaws.services.dynamodbv2.document.spec.QuerySpec;
 import com.amazonaws.services.dynamodbv2.document.utils.ValueMap;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import com.yammer.metrics.Metrics;
@@ -764,8 +763,12 @@ public class DynamoDBFeedSource implements FeedSource {
         valueMap.withString(":feed", persistedEntry.getFeed());
 
         for(String s: categoriesList){
-
-            valueMap.withString(":categories", s);
+            if(s.charAt(0) == '{'){
+                valueMap.withString(":categories", s.substring(1,s.length() -1));
+            }else{
+                valueMap.withString(":categories", s);
+            }
+            
         }
 
         firstUnionPersistentList = getQueryBuilderMethod(dynamoDB, "feed = :feed ",filterExpression, valueMap);

--- a/adapters/dynamoDB_adapters/src/main/java/org/atomhopper/dynamodb/query/CategoryStringGenerator.java
+++ b/adapters/dynamoDB_adapters/src/main/java/org/atomhopper/dynamodb/query/CategoryStringGenerator.java
@@ -28,49 +28,34 @@ public final class CategoryStringGenerator {
     public static List<String> getPostgresCategoryString(String searchString, Map<String, String> mapPrefix, String prefixSplit ) {
 
         List<String> finalList = new ArrayList<String>();
-
-
         if (searchString == null || !(searchString.trim().length() > 0)) {
-
             finalList.add( "{}" );
             return finalList;
         }
 
         List<String> categories = parse(searchString.trim().toLowerCase());
-
         List<String> catHolder = new ArrayList<String>();
 
         // find if any categories are prefixed, if so, split them out.
         for( String cat : categories ) {
-
             if (cat.matches( SQLToNoSqlConverter.BAD_SEARCH_REGEX ) ) {
-
                 throw new IllegalArgumentException( SQLToNoSqlConverter.BAD_CHAR_MSG );
             }
 
-
             if (prefixSplit != null ) {
-
                 int index = cat.indexOf( prefixSplit );
-
                 if ( index != -1 ) {
-
                     String prefix = cat.substring( 0, index );
-                    String value = cat.substring( index + prefixSplit.length() );
 
                     if ( mapPrefix.containsKey( prefix ) ) {
-
                         addToFinalList( finalList, catHolder );
-
-                        finalList.add( value );
+                        finalList.add( cat );
                     }
                     else {
-
                         catHolder.add( cat );
                     }
                 }
                 else {
-
                     catHolder.add( cat );
                 }
             }
@@ -80,7 +65,6 @@ public final class CategoryStringGenerator {
         }
 
         addToFinalList( finalList, catHolder );
-
         return finalList;
     }
 

--- a/adapters/dynamoDB_adapters/src/main/java/org/atomhopper/dynamodb/query/SQLToNoSqlConverter.java
+++ b/adapters/dynamoDB_adapters/src/main/java/org/atomhopper/dynamodb/query/SQLToNoSqlConverter.java
@@ -276,15 +276,11 @@ public class SQLToNoSqlConverter {
                 if( prefixSplit != null ) {
 
                     int index = filter.getAssertionValue().indexOf( prefixSplit );
-
                     if ( index != -1 ) {
 
                         String prefix = filter.getAssertionValue().substring( 0, index );
-                        String value = filter.getAssertionValue().substring( index + prefixSplit.length() );
-
                         if ( mapPrefix.containsKey( prefix ) ) {
-
-                            param = value;
+                            param = filter.getAssertionValue();
                         }
                     }
                 }


### PR DESCRIPTION
**Issues**

1. All the feeds created by admin were coming in the other role calls.
2. No filtering was being done according to the tenant id. 
3. Both type of tenant search old and new were failing. 

**Resolutions:** 

1. Filter params were created in the dynamodb adapter DynamoDBFeedSource.java , but were never used. So instead of creating the params, we have created the filter for categories. 
2. khannakavish/cloudfeeds-atomhopper:v234 --> Can use this docker image for testing. 
3. In CategoryStringGenerator.java and SQLToNoSqlConverter.java changed the value of the categories field going to filter the output. 